### PR TITLE
Add home and takeout food modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# MealMatch repository guide
+
+## Purpose and sources of truth
+
+MealMatch is a collaborative meal-decision app. A group creates a session, votes on the available meals with swipe gestures, and sees ranked results after the session closes.
+
+- Treat the implementation, tests, and package scripts as the source of truth.
+- `SPEC.MD` describes the original product direction and `CLAUDE.md` contains useful historical guidance, but both predate parts of the current implementation. Do not copy their API or schema examples without checking the code.
+- Keep this file focused on durable repository facts. Update it when architecture, commands, or cross-cutting invariants change.
+
+## Current product flows
+
+- The public home page (`/`) creates an account-free quick session. It defaults to takeout categories, still supports home meals, auto-joins the creator, stores participant/session data in browser storage, and gives an anonymous creator a secret token that can close the session.
+- Authenticated hosts can register or log in, manage separate home-meal and takeout-category libraries, create sessions, monitor participants, close sessions, view voter details, and select the final option.
+- A new authenticated takeout library starts with a one-time onboarding choice: select popular categories or add a custom category. The dismissal is stored on the host record, and creating any takeout category also dismisses it, so onboarding does not return when the library later becomes empty.
+- Other participants join through a six-character invite code. The meal pool is fixed when a session is created, but a participant can update submitted choices while the session remains open.
+- Votes are numeric across every layer: `0 = no`, `1 = yes`, and `2 = maybe`. Results treat yes and maybe as acceptable, treat only all-yes as unanimous, and rank tied acceptance percentages by fewer maybes.
+
+## Repository map
+
+- `client/`: React 18, TypeScript, Vite, Tailwind CSS, React Router, Framer Motion, Vitest, and Testing Library.
+- `server/`: Express, TypeScript, `sql.js` SQLite persistence, cookie sessions, and Vitest.
+- `e2e/`: Playwright coverage for quick sessions, authenticated hosts, meal management, session lifecycle, and maybe votes.
+- `agents/orchestrator/`: a separate Node/TypeScript GitHub-issue orchestrator with its own dependencies, build, tests, state database, and Claude-oriented prompts. It is not part of the MealMatch runtime or root test command. Do not migrate or redesign it as part of an application change unless explicitly requested.
+- `SPEC.MD`: original product specification.
+- `CLAUDE.md`: legacy agent notes; useful context, not an automatically authoritative Codex instruction file.
+
+## Setup and development
+
+Use npm and preserve the root, client, and server lockfiles, plus the orchestrator lockfile when its package changes. The root install command does not install orchestrator dependencies.
+
+```bash
+npm run install:all
+npm run dev
+npm run dev:client
+npm run dev:server
+
+# Only when working on agents/orchestrator
+npm --prefix agents/orchestrator install
+```
+
+Development defaults are client `http://localhost:5173` and API `http://localhost:3000`; Vite proxies `/api` to the server. In production, Express serves `client/dist` and owns the SPA fallback.
+
+The normal production environment needs `SESSION_SECRET` and may set `PORT`, `NODE_ENV=production`, and `DATABASE_PATH`. Railway should mount persistent storage and set `DATABASE_PATH` to the mounted database. Never commit environment files, tokens, database files, or production data.
+
+## Verification
+
+Run checks proportional to the change. The root unit-test command covers the server and client, but not Playwright or the orchestrator.
+
+```bash
+# Server and client unit tests
+npm test
+
+# Client lint
+npm run lint
+
+# Production type-check/build without reinstalling dependencies
+npm --prefix client run build
+npm --prefix server run build
+
+# End-to-end tests (starts the dev servers through Playwright config)
+npm run test:e2e
+
+# Separate orchestrator checks, when agents/orchestrator changes
+npm --prefix agents/orchestrator test
+npm --prefix agents/orchestrator run build
+```
+
+Prefer the two direct package builds during routine verification. Root `npm run build` invokes `build.sh`, which runs `npm install` inside both packages and requires a Bash-compatible shell.
+
+Playwright writes to `playwright-report/` and `test-results/`. Those paths are ignored, but `test-results/.last-run.json` is still tracked from older history. Preserve any pre-existing change to that file and do not include generated test output in a feature diff.
+Playwright starts its server with a per-run database under `test-results/` and does not reuse an existing development server unless `PLAYWRIGHT_REUSE_SERVER=1` is explicitly set. Keep this isolation so end-to-end tests do not pollute a developer's persistent local database.
+
+## Cross-layer invariants
+
+- SQLite booleans are numbers (`0` or `1`). Convert them to booleans at API boundaries where the client type is boolean. In JSX, do not render a raw numeric database flag with `flag && ...`, because `0` is renderable text.
+- Keep the vote domain synchronized in server types and validation, matching logic, client API types, local-storage progress, swipe components, results UI, and tests. Search all vote usages before changing it.
+- A session has one mode: `home` or `takeout`. Stored options have a separate type: `meal`, `category`, or the reserved future `restaurant`. Home sessions currently accept only meals, takeout sessions accept only categories, and the server must reject mixed or mismatched IDs. Do not change matching behavior based on mode.
+- Host preferences stored as SQLite flags must be converted to booleans in authentication API responses. Keep their fresh-schema columns, additive migrations, API types, and client callers aligned.
+- Keep `createTables` and `runMigrations` in `server/src/db/schema.ts` aligned. The project has a small additive migration mechanism rather than a migration framework.
+- `runQuery` persists the full `sql.js` database after each write. Be conscious of write ordering and partial updates in multi-step handlers.
+- Protect authenticated host routes with both authentication and resource ownership checks. Anonymous close operations must validate the creator token without returning or logging it.
+- Express session storage currently uses the package default memory store. Do not assume login sessions are durable across server restarts or multiple production instances.
+- Public result responses must not expose voter identities. Host voter detail is allowed only after server-side host verification; a query-string flag alone is not authorization.
+- Browser recovery uses both `sessionStorage` for join/session context and `localStorage` for in-progress swipes. Preserve the storage contracts when changing join, share, swipe, edit, or result flows.
+- Declare React hooks before conditional returns and keep effect dependencies accurate. Add regression coverage for async navigation, polling, and storage behavior.
+
+## Change workflow
+
+- Check `git status` before editing and preserve unrelated or pre-existing work.
+- Make the smallest coherent change; avoid new production dependencies unless they materially simplify the requested behavior.
+- For an API contract change, update the route, `server/src/types.ts`, `client/src/api/client.ts`, all consumers, and tests together.
+- For a schema change, update fresh-database creation, existing-database migration, server types, queries, and tests together.
+- Add or adjust tests next to the affected code. Use Playwright when behavior spans browser storage, multiple participants, authentication, or the client/server boundary.
+- Do not hand-edit generated output in `dist/`, Playwright reports, test results, coverage, databases, or installed dependencies.
+
+## Code review priorities
+
+Give extra scrutiny to authorization and ownership, creator-token secrecy, vote-value consistency, partial database writes, session-close races, voter-detail privacy, browser-storage recovery, and client/API response-shape drift. Report behavior and security risks before style-only observations.

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { participantApi } from './client';
+import { mealsApi, participantApi } from './client';
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -47,5 +47,20 @@ describe('API Client - Session Closed Handling', () => {
       expect(error.message).toBe('Some other error');
       expect(error.sessionClosed).toBe(false);
     }
+  });
+
+  it('preserves the existing record ID for duplicate library options', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({
+        error: 'A food category with this name already exists',
+        existingId: 'category-123',
+      }),
+    });
+
+    await expect(mealsApi.create('Pizza', undefined, 'category')).rejects.toMatchObject({
+      existingId: 'category-123',
+      sessionClosed: false,
+    });
   });
 });

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -3,15 +3,18 @@ const API_BASE = '/api';
 interface ApiError {
   error: string;
   sessionClosed?: boolean;
+  existingId?: string;
 }
 
-class ApiException extends Error {
+export class ApiException extends Error {
   sessionClosed: boolean;
+  existingId?: string;
 
-  constructor(message: string, sessionClosed: boolean = false) {
+  constructor(message: string, sessionClosed: boolean = false, existingId?: string) {
     super(message);
     this.name = 'ApiException';
     this.sessionClosed = sessionClosed;
+    this.existingId = existingId;
   }
 }
 
@@ -32,7 +35,11 @@ async function request<T>(
 
   if (!response.ok) {
     const error = data as ApiError;
-    throw new ApiException(error.error || 'An error occurred', error.sessionClosed || false);
+    throw new ApiException(
+      error.error || 'An error occurred',
+      error.sessionClosed || false,
+      error.existingId
+    );
   }
 
   return data as T;
@@ -43,6 +50,7 @@ export interface User {
   id: string;
   email: string;
   createdAt?: string;
+  takeoutOnboardingDismissed?: boolean;
 }
 
 export const authApi = {
@@ -62,28 +70,39 @@ export const authApi = {
     request<{ message: string }>('/auth/logout', { method: 'POST' }),
 
   getMe: () => request<User>('/auth/me'),
+
+  updatePreferences: (takeoutOnboardingDismissed: boolean) =>
+    request<User>('/auth/preferences', {
+      method: 'PATCH',
+      body: JSON.stringify({ takeoutOnboardingDismissed }),
+    }),
 };
 
 // Meals API
+export type SessionMode = 'home' | 'takeout';
+export type MealType = 'meal' | 'category' | 'restaurant';
+
 export interface Meal {
   id: string;
   title: string;
   description: string | null;
-  type: string;
+  type: MealType;
   pickCount: number;
   createdAt?: string;
   archived?: boolean;
 }
 
 export const mealsApi = {
-  list: () => request<Meal[]>('/meals'),
+  list: (type?: MealType) =>
+    request<Meal[]>(`/meals${type ? `?type=${type}` : ''}`),
 
-  listAll: () => request<Meal[]>('/meals/all'),
+  listAll: (type?: MealType) =>
+    request<Meal[]>(`/meals/all${type ? `?type=${type}` : ''}`),
 
-  create: (title: string, description?: string) =>
+  create: (title: string, description?: string, type: MealType = 'meal') =>
     request<Meal>('/meals', {
       method: 'POST',
-      body: JSON.stringify({ title, description }),
+      body: JSON.stringify({ title, description, type }),
     }),
 
   update: (id: string, data: { title?: string; description?: string }) =>
@@ -104,6 +123,7 @@ export interface Session {
   id: string;
   inviteCode: string;
   status: 'open' | 'closed';
+  mode: SessionMode;
   selectedMealId: string | null;
   mealCount: number;
   participantCount: number;
@@ -112,7 +132,7 @@ export interface Session {
 }
 
 export interface SessionDetails extends Session {
-  meals: Array<{ id: string; title: string; description: string | null }>;
+  meals: Array<{ id: string; title: string; description: string | null; type: MealType }>;
   participants: Array<{
     id: string;
     displayName: string;
@@ -137,12 +157,12 @@ export interface MatchResult {
 export const sessionsApi = {
   list: () => request<Session[]>('/sessions'),
 
-  create: (mealIds: string[]) =>
-    request<{ id: string; inviteCode: string; status: string; mealCount: number }>(
+  create: (mealIds: string[], mode: SessionMode = 'home') =>
+    request<{ id: string; inviteCode: string; status: string; mode: SessionMode; mealCount: number }>(
       '/sessions',
       {
         method: 'POST',
-        body: JSON.stringify({ mealIds }),
+        body: JSON.stringify({ mealIds, mode }),
       }
     ),
 
@@ -165,29 +185,33 @@ export const sessionsApi = {
 export interface JoinSessionResponse {
   participantId: string;
   sessionId: string;
+  mode: SessionMode;
   meals: Array<{
     id: string;
     title: string;
     description: string | null;
+    type: MealType;
     sessionMealId: string;
   }>;
 }
 
 export interface ResultsResponse {
   status: 'waiting' | 'closed';
+  mode: SessionMode;
   message?: string;
   results?: MatchResult[];
   selectedMeal?: {
     id: string;
     title: string;
     description: string | null;
+    type: MealType;
   } | null;
   isHost?: boolean;
 }
 
 export const participantApi = {
   getSession: (inviteCode: string) =>
-    request<{ id: string; status: string; participantCount: number }>(
+    request<{ id: string; status: string; mode: SessionMode; participantCount: number }>(
       `/join/${inviteCode}`
     ),
 
@@ -213,6 +237,7 @@ export const participantApi = {
   getSessionStatus: (sessionId: string) =>
     request<{
       status: string;
+      mode: SessionMode;
       selectedMealId: string | null;
       participants: Array<{
         id: string;
@@ -234,6 +259,7 @@ export interface QuickSessionResponse {
     id: string;
     inviteCode: string;
     status: string;
+    mode: SessionMode;
   };
   participantId: string;
   creatorToken: string | null;
@@ -241,14 +267,19 @@ export interface QuickSessionResponse {
     id: string;
     title: string;
     description: string | null;
+    type: MealType;
     sessionMealId: string;
   }>;
 }
 
 export const quickSessionApi = {
-  create: (creatorName: string, meals: Array<{ title: string; description?: string }>) =>
+  create: (
+    creatorName: string,
+    meals: Array<{ title: string; description?: string }>,
+    mode: SessionMode = 'home'
+  ) =>
     request<QuickSessionResponse>('/quick-session', {
       method: 'POST',
-      body: JSON.stringify({ creatorName, meals }),
+      body: JSON.stringify({ creatorName, meals, mode }),
     }),
 };

--- a/client/src/constants/takeoutCategories.ts
+++ b/client/src/constants/takeoutCategories.ts
@@ -1,0 +1,14 @@
+export const TAKEOUT_CATEGORY_SUGGESTIONS = [
+  'Pizza',
+  'Mexican',
+  'Chinese',
+  'Thai',
+  'Indian',
+  'Italian',
+  'Burgers',
+  'Sandwiches',
+  'Sushi',
+  'Ramen',
+  'Mediterranean',
+  'BBQ',
+] as const;

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Dashboard } from './Dashboard';
-import { mealsApi, sessionsApi } from '../api/client';
+import { authApi, mealsApi, sessionsApi, Meal } from '../api/client';
 
 vi.mock('../hooks/useAuth', () => ({
   useAuth: () => ({
@@ -12,6 +12,9 @@ vi.mock('../hooks/useAuth', () => ({
 }));
 
 vi.mock('../api/client', () => ({
+  authApi: {
+    updatePreferences: vi.fn(),
+  },
   mealsApi: {
     list: vi.fn(),
     create: vi.fn(),
@@ -24,10 +27,9 @@ vi.mock('../api/client', () => ({
   },
 }));
 
-const mockMeals = [
+const mockMeals: Meal[] = [
   {
     id: '1',
-    hostId: 'host1',
     title: 'Pizza',
     description: 'Pepperoni pizza',
     type: 'meal',
@@ -37,7 +39,6 @@ const mockMeals = [
   },
   {
     id: '2',
-    hostId: 'host1',
     title: 'Tacos',
     description: 'Beef tacos',
     type: 'meal',
@@ -47,7 +48,6 @@ const mockMeals = [
   },
   {
     id: '3',
-    hostId: 'host1',
     title: 'Pasta',
     description: 'Spaghetti',
     type: 'meal',
@@ -705,9 +705,8 @@ describe('Dashboard - Quick Add Meal in Create Session', () => {
   });
 
   it('should add meal via quick add and auto-select it', async () => {
-    const newMeal = {
+    const newMeal: Meal = {
       id: '4',
-      hostId: 'host1',
       title: 'Burger',
       description: '',
       type: 'meal',
@@ -747,9 +746,8 @@ describe('Dashboard - Quick Add Meal in Create Session', () => {
   });
 
   it('should clear input after quick add', async () => {
-    const newMeal = {
+    const newMeal: Meal = {
       id: '4',
-      hostId: 'host1',
       title: 'Burger',
       description: '',
       type: 'meal',
@@ -785,9 +783,8 @@ describe('Dashboard - Quick Add Meal in Create Session', () => {
   });
 
   it('should submit quick add on Enter key', async () => {
-    const newMeal = {
+    const newMeal: Meal = {
       id: '4',
-      hostId: 'host1',
       title: 'Burger',
       description: '',
       type: 'meal',
@@ -839,9 +836,8 @@ describe('Dashboard - Quick Add Meal in Create Session', () => {
   });
 
   it('should trim whitespace from quick add input', async () => {
-    const newMeal = {
+    const newMeal: Meal = {
       id: '4',
-      hostId: 'host1',
       title: 'Burger',
       description: '',
       type: 'meal',
@@ -901,5 +897,144 @@ describe('Dashboard - Quick Add Meal in Create Session', () => {
     await waitFor(() => {
       expect(screen.getByText('Failed to create meal')).toBeDefined();
     });
+  });
+});
+
+describe('Dashboard - Home and takeout modes', () => {
+  const mockCategories: Meal[] = [
+    {
+      id: 'category-1',
+      title: 'Sushi',
+      description: null,
+      type: 'category',
+      archived: false,
+      pickCount: 0,
+      createdAt: '2024-01-05',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authApi.updatePreferences).mockResolvedValue({
+      id: '1',
+      email: 'test@example.com',
+      takeoutOnboardingDismissed: true,
+    });
+    vi.mocked(mealsApi.list).mockImplementation(async (type) =>
+      type === 'category' ? mockCategories : mockMeals
+    );
+    vi.mocked(sessionsApi.list).mockResolvedValue([]);
+  });
+
+  it('filters the library by tab and opens the session modal in the active mode', async () => {
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Takeout' }));
+
+    expect(screen.getByText('My Food Categories')).toBeInTheDocument();
+    expect(screen.getByText('Sushi')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Session' }));
+    expect(screen.getByText('Quick add category')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cook at home' }));
+    expect(screen.getByText('Quick add meal')).toBeInTheDocument();
+    expect(screen.getAllByText('Tacos').length).toBeGreaterThan(0);
+  });
+
+  it('saves and selects a missing takeout suggestion in one action', async () => {
+    const mexicanCategory: Meal = {
+      id: 'category-2',
+      title: 'Mexican',
+      description: null,
+      type: 'category',
+      archived: false,
+      pickCount: 0,
+    };
+    vi.mocked(mealsApi.create).mockResolvedValue(mexicanCategory);
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Takeout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create Session' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Mexican' }));
+
+    await waitFor(() => {
+      expect(mealsApi.create).toHaveBeenCalledWith('Mexican', undefined, 'category');
+      expect(screen.getByRole('button', { name: /Create \(2 options\)/ })).toBeInTheDocument();
+    });
+  });
+
+  it('only saves checked popular categories when onboarding is submitted', async () => {
+    const barbecueCategory: Meal = {
+      id: 'category-3',
+      title: 'BBQ',
+      description: null,
+      type: 'category',
+      archived: false,
+      pickCount: 0,
+    };
+    vi.mocked(mealsApi.create).mockResolvedValue(barbecueCategory);
+    vi.mocked(mealsApi.list).mockImplementation(async (type) =>
+      type === 'category' ? [] : mockMeals
+    );
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Takeout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Start with popular categories' }));
+
+    const barbecue = screen.getByRole('checkbox', { name: 'BBQ' });
+    fireEvent.click(barbecue);
+    expect(barbecue).toBeChecked();
+    expect(mealsApi.create).not.toHaveBeenCalled();
+
+    fireEvent.click(barbecue);
+    expect(barbecue).not.toBeChecked();
+    expect(mealsApi.create).not.toHaveBeenCalled();
+
+    fireEvent.click(barbecue);
+    fireEvent.click(screen.getByRole('button', { name: 'Add selected (1)' }));
+
+    await waitFor(() => {
+      expect(mealsApi.create).toHaveBeenCalledWith('BBQ', undefined, 'category');
+    });
+  });
+
+  it('keeps popular categories out of the normal add-category form after choosing to add its own', async () => {
+    vi.mocked(mealsApi.list).mockImplementation(async (type) =>
+      type === 'category' ? [] : mockMeals
+    );
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Takeout' }));
+    fireEvent.click(screen.getByRole('button', { name: "I'll add my own" }));
+
+    await waitFor(() => {
+      expect(authApi.updatePreferences).toHaveBeenCalledWith(true);
+      expect(screen.getByText('Add Food Category')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Popular categories')).not.toBeInTheDocument();
   });
 });

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../hooks/useAuth';
-import { mealsApi, sessionsApi, Meal, Session } from '../api/client';
+import { authApi, mealsApi, sessionsApi, Meal, Session, SessionMode } from '../api/client';
 import ConfirmModal from '../components/ConfirmModal';
+import { TAKEOUT_CATEGORY_SUGGESTIONS } from '../constants/takeoutCategories';
 
 export function Dashboard() {
   const { user, logout } = useAuth();
@@ -12,6 +13,7 @@ export function Dashboard() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [activeMode, setActiveMode] = useState<SessionMode>('home');
 
   // Modal states
   const [showAddMeal, setShowAddMeal] = useState(false);
@@ -20,6 +22,13 @@ export function Dashboard() {
   const [newMealDescription, setNewMealDescription] = useState('');
   const [selectedMealIds, setSelectedMealIds] = useState<string[]>([]);
   const [quickAddTitle, setQuickAddTitle] = useState('');
+  const [sessionMode, setSessionMode] = useState<SessionMode>('home');
+  const [addingSuggestion, setAddingSuggestion] = useState<string | null>(null);
+  const [showTakeoutOnboarding, setShowTakeoutOnboarding] = useState(false);
+  const [selectedStarterCategories, setSelectedStarterCategories] = useState<string[]>([]);
+  const [takeoutOnboardingDismissed, setTakeoutOnboardingDismissed] = useState(
+    Boolean(user?.takeoutOnboardingDismissed)
+  );
 
   // Edit mode states
   const [editMode, setEditMode] = useState(false);
@@ -38,17 +47,30 @@ export function Dashboard() {
   // Animation states
   const [deletingMealIds, setDeletingMealIds] = useState<string[]>([]);
 
+  const activeType = activeMode === 'home' ? 'meal' : 'category';
+  const activeMeals = meals.filter((meal) => meal.type === activeType);
+  const sessionType = sessionMode === 'home' ? 'meal' : 'category';
+  const sessionMeals = meals.filter((meal) => meal.type === sessionType);
+
   useEffect(() => {
     loadData();
   }, []);
 
+  useEffect(() => {
+    setTakeoutOnboardingDismissed(Boolean(user?.takeoutOnboardingDismissed));
+  }, [user?.takeoutOnboardingDismissed]);
+
   const loadData = async () => {
     try {
-      const [mealsData, sessionsData] = await Promise.all([
-        mealsApi.list(),
+      const [homeMealsData, categoriesData, sessionsData] = await Promise.all([
+        mealsApi.list('meal'),
+        mealsApi.list('category'),
         sessionsApi.list(),
       ]);
-      setMeals(mealsData);
+      setMeals([
+        ...homeMealsData.filter((meal) => meal.type === 'meal'),
+        ...categoriesData.filter((meal) => meal.type === 'category'),
+      ]);
       setSessions(sessionsData);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load data');
@@ -57,16 +79,83 @@ export function Dashboard() {
     }
   };
 
+  const markTakeoutOnboardingComplete = async (): Promise<boolean> => {
+    try {
+      await authApi.updatePreferences(true);
+      setTakeoutOnboardingDismissed(true);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save your takeout setup preference');
+      return false;
+    }
+  };
+
   const handleAddMeal = async (e: React.FormEvent) => {
     e.preventDefault();
+
     try {
-      const meal = await mealsApi.create(newMealTitle, newMealDescription || undefined);
-      setMeals([meal, ...meals]);
+      const meal = activeMode === 'home'
+        ? await mealsApi.create(newMealTitle.trim(), newMealDescription || undefined)
+        : await mealsApi.create(newMealTitle.trim(), undefined, 'category');
+      setMeals((current) => [meal, ...current]);
       setNewMealTitle('');
       setNewMealDescription('');
       setShowAddMeal(false);
+      if (activeMode === 'takeout') {
+        setTakeoutOnboardingDismissed(true);
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add meal');
+      setError(err instanceof Error ? err.message : `Failed to add ${activeMode === 'home' ? 'meal' : 'category'}`);
+    }
+  };
+
+  const openAddMeal = () => {
+    setNewMealTitle('');
+    setNewMealDescription('');
+    setShowAddMeal(true);
+  };
+
+  const closeAddMeal = () => {
+    setNewMealTitle('');
+    setNewMealDescription('');
+    setShowAddMeal(false);
+  };
+
+  const toggleStarterCategory = (title: string) => {
+    setSelectedStarterCategories((current) =>
+      current.includes(title)
+        ? current.filter((suggestion) => suggestion !== title)
+        : [...current, title]
+    );
+  };
+
+  const openTakeoutOnboarding = () => {
+    setSelectedStarterCategories([]);
+    setShowTakeoutOnboarding(true);
+  };
+
+  const handleAddStarterCategories = async () => {
+    if (selectedStarterCategories.length === 0) {
+      setError('Choose at least one category to add');
+      return;
+    }
+
+    try {
+      const categories = await Promise.all(
+        selectedStarterCategories.map((title) => mealsApi.create(title, undefined, 'category'))
+      );
+      setMeals((current) => [...categories, ...current]);
+      setShowTakeoutOnboarding(false);
+      setSelectedStarterCategories([]);
+      setTakeoutOnboardingDismissed(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add food categories');
+    }
+  };
+
+  const handleAddOwnCategory = async () => {
+    if (await markTakeoutOnboardingComplete()) {
+      openAddMeal();
     }
   };
 
@@ -84,11 +173,17 @@ export function Dashboard() {
     try {
       await mealsApi.update(editingMeal.id, {
         title: editTitle,
-        description: editDescription || undefined,
+        ...(editingMeal.type === 'meal'
+          ? { description: editDescription || undefined }
+          : {}),
       });
       setMeals(meals.map((m) =>
         m.id === editingMeal.id
-          ? { ...m, title: editTitle, description: editDescription || null }
+          ? {
+              ...m,
+              title: editTitle,
+              description: editingMeal.type === 'meal' ? editDescription || null : null,
+            }
           : m
       ));
       setShowEditMeal(false);
@@ -169,12 +264,12 @@ export function Dashboard() {
 
   const handleCreateSession = async () => {
     if (selectedMealIds.length === 0) {
-      setError('Select at least one meal');
+      setError('Select at least one option');
       return;
     }
 
     try {
-      const session = await sessionsApi.create(selectedMealIds);
+      const session = await sessionsApi.create(selectedMealIds, sessionMode);
       navigate(`/session/${session.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create session');
@@ -187,8 +282,23 @@ export function Dashboard() {
   };
 
   const openCreateSession = () => {
-    setSelectedMealIds(meals.map((m) => m.id)); // Select all by default
+    setSessionMode(activeMode);
+    setSelectedMealIds(activeMeals.map((meal) => meal.id));
+    setQuickAddTitle('');
     setShowCreateSession(true);
+  };
+
+  const changeSessionMode = (mode: SessionMode) => {
+    setSessionMode(mode);
+    const type = mode === 'home' ? 'meal' : 'category';
+    setSelectedMealIds(meals.filter((meal) => meal.type === type).map((meal) => meal.id));
+    setQuickAddTitle('');
+  };
+
+  const changeActiveMode = (mode: SessionMode) => {
+    setActiveMode(mode);
+    setEditMode(false);
+    setSelectedForDeletion([]);
   };
 
   const toggleMealSelection = (id: string) => {
@@ -202,12 +312,46 @@ export function Dashboard() {
     if (!quickAddTitle.trim()) return;
 
     try {
-      const meal = await mealsApi.create(quickAddTitle.trim(), undefined);
-      setMeals([meal, ...meals]);
-      setSelectedMealIds([...selectedMealIds, meal.id]);
+      const meal = sessionMode === 'home'
+        ? await mealsApi.create(quickAddTitle.trim(), undefined)
+        : await mealsApi.create(quickAddTitle.trim(), undefined, 'category');
+      setMeals((current) => [meal, ...current]);
+      setSelectedMealIds((current) => [...current, meal.id]);
       setQuickAddTitle('');
+      if (sessionMode === 'takeout') {
+        setTakeoutOnboardingDismissed(true);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add meal');
+    }
+  };
+
+  const handleTakeoutSuggestion = async (title: string, selectForSession: boolean) => {
+    const existing = meals.find(
+      (meal) => meal.type === 'category' && meal.title.toLowerCase() === title.toLowerCase()
+    );
+
+    if (existing) {
+      if (selectForSession) {
+        setSelectedMealIds((current) =>
+          current.includes(existing.id) ? current : [...current, existing.id]
+        );
+      }
+      return;
+    }
+
+    setAddingSuggestion(title);
+    try {
+      const category = await mealsApi.create(title, undefined, 'category');
+      setMeals((current) => [category, ...current]);
+      setTakeoutOnboardingDismissed(true);
+      if (selectForSession) {
+        setSelectedMealIds((current) => [...current, category.id]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add food category');
+    } finally {
+      setAddingSuggestion(null);
     }
   };
 
@@ -244,12 +388,33 @@ export function Dashboard() {
           </div>
         )}
 
-        {/* Meals Section */}
+        {/* Saved options */}
         <section className="mb-12">
+          <div className="inline-flex rounded-lg bg-gray-100 p-1 mb-6" aria-label="Food library">
+            <button
+              onClick={() => changeActiveMode('home')}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                activeMode === 'home' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-600'
+              }`}
+            >
+              Home meals
+            </button>
+            <button
+              onClick={() => changeActiveMode('takeout')}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                activeMode === 'takeout' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-600'
+              }`}
+            >
+              Takeout
+            </button>
+          </div>
+
           <div className="flex justify-between items-center mb-4">
             <div className="flex items-center gap-3">
-              <h2 className="text-2xl font-bold">My Meals</h2>
-              {meals.length > 0 && (
+              <h2 className="text-2xl font-bold">
+                {activeMode === 'home' ? 'My Meals' : 'My Food Categories'}
+              </h2>
+              {activeMeals.length > 0 && (
                 <>
                   <button
                     onClick={toggleEditMode}
@@ -269,23 +434,44 @@ export function Dashboard() {
               )}
             </div>
             {!editMode && (
-              <button onClick={() => setShowAddMeal(true)} className="btn btn-primary">
-                Add Meal
+              <button onClick={openAddMeal} className="btn btn-primary">
+                {activeMode === 'home' ? 'Add Meal' : 'Add Category'}
               </button>
             )}
           </div>
 
-          {meals.length === 0 ? (
-            <div className="card text-center py-12">
-              <p className="text-gray-500 mb-4">No meals yet. Add some to get started!</p>
-              <button onClick={() => setShowAddMeal(true)} className="btn btn-primary">
-                Add Your First Meal
-              </button>
-            </div>
+          {activeMeals.length === 0 ? (
+            activeMode === 'takeout' && !takeoutOnboardingDismissed ? (
+              <div className="card text-center py-12">
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">Build your takeout list</h3>
+                <p className="text-gray-500 mb-5">
+                  Start with a few popular categories, or add your own from scratch.
+                </p>
+                <div className="flex flex-col sm:flex-row justify-center gap-3">
+                  <button onClick={openTakeoutOnboarding} className="btn btn-primary">
+                    Start with popular categories
+                  </button>
+                  <button onClick={handleAddOwnCategory} className="btn btn-secondary">
+                    I&apos;ll add my own
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="card text-center py-12">
+                <p className="text-gray-500 mb-4">
+                  {activeMode === 'home'
+                    ? 'No meals yet. Add some to get started!'
+                    : 'No takeout categories yet. Add your favorites to get started!'}
+                </p>
+                <button onClick={openAddMeal} className="btn btn-primary">
+                  {activeMode === 'home' ? 'Add Your First Meal' : 'Add Your First Category'}
+                </button>
+              </div>
+            )
           ) : (
             <div className="grid gap-4 sm:grid-cols-2">
               <AnimatePresence mode="popLayout">
-                {meals.map((meal) => {
+                {activeMeals.map((meal) => {
                   const isDeleting = deletingMealIds.includes(meal.id);
                   const isSingleDelete = deletingMealIds.length === 1 && isDeleting;
 
@@ -335,7 +521,7 @@ export function Dashboard() {
                             <button
                               onClick={() => openEditMeal(meal)}
                               className="text-gray-400 hover:text-primary-500"
-                              title="Edit meal"
+                              title={meal.type === 'category' ? 'Edit category' : 'Edit meal'}
                             >
                               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
@@ -344,7 +530,7 @@ export function Dashboard() {
                             <button
                               onClick={() => confirmDeleteSingleMeal(meal)}
                               className="text-gray-400 hover:text-red-500"
-                              title="Archive meal"
+                              title={meal.type === 'category' ? 'Archive category' : 'Archive meal'}
                             >
                               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -381,7 +567,7 @@ export function Dashboard() {
           </div>
           {meals.length === 0 ? (
             <p className="text-sm text-gray-600 mt-2 text-center">
-              Add meals to create a session from your library, or use Quick Session to start immediately.
+              Add saved options to create a session from your library, or use Quick Session to start immediately.
             </p>
           ) : null}
         </section>
@@ -406,6 +592,9 @@ export function Dashboard() {
                     <div>
                       <div className="flex items-center gap-2">
                         <span className="font-mono font-bold text-lg">{session.inviteCode}</span>
+                        <span className="px-2 py-0.5 rounded text-xs font-medium bg-orange-50 text-orange-700">
+                          {session.mode === 'takeout' ? 'Order out' : 'Cook at home'}
+                        </span>
                         <span
                           className={`px-2 py-0.5 rounded text-xs font-medium ${
                             session.status === 'open'
@@ -417,7 +606,7 @@ export function Dashboard() {
                         </span>
                       </div>
                       <p className="text-sm text-gray-500 mt-1">
-                        {session.mealCount} meals · {session.participantCount} participants
+                        {session.mealCount} options · {session.participantCount} participants
                       </p>
                     </div>
                     <svg
@@ -436,11 +625,68 @@ export function Dashboard() {
         </section>
       </main>
 
+      {/* Takeout onboarding modal */}
+      {showTakeoutOnboarding && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="card w-full max-w-lg">
+            <h3 className="text-xl font-bold mb-2">Start with popular categories</h3>
+            <p className="text-sm text-gray-600 mb-5">
+              Pick the kinds of food you&apos;d like to consider. You can always add or remove categories later.
+            </p>
+            <fieldset>
+              <legend className="sr-only">Popular categories</legend>
+              <div className="grid grid-cols-2 gap-2">
+                {TAKEOUT_CATEGORY_SUGGESTIONS.map((suggestion) => {
+                  const selected = selectedStarterCategories.includes(suggestion);
+                  return (
+                    <label
+                      key={suggestion}
+                      className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm cursor-pointer transition-colors ${
+                        selected
+                          ? 'bg-orange-100 border-orange-300 text-orange-800'
+                          : 'bg-white border-gray-300 text-gray-700 hover:border-orange-400'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={() => toggleStarterCategory(suggestion)}
+                        className="accent-orange-500"
+                      />
+                      {suggestion}
+                    </label>
+                  );
+                })}
+              </div>
+            </fieldset>
+            <div className="flex gap-3 mt-6">
+              <button
+                type="button"
+                onClick={() => setShowTakeoutOnboarding(false)}
+                className="btn btn-secondary flex-1"
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                onClick={handleAddStarterCategories}
+                disabled={selectedStarterCategories.length === 0}
+                className="btn btn-primary flex-1"
+              >
+                Add selected ({selectedStarterCategories.length})
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Add Meal Modal */}
       {showAddMeal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="card w-full max-w-md">
-            <h3 className="text-xl font-bold mb-4">Add New Meal</h3>
+            <h3 className="text-xl font-bold mb-4">
+              {activeMode === 'home' ? 'Add New Meal' : 'Add Food Category'}
+            </h3>
             <form onSubmit={handleAddMeal} className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -451,12 +697,12 @@ export function Dashboard() {
                   value={newMealTitle}
                   onChange={(e) => setNewMealTitle(e.target.value)}
                   className="input"
-                  placeholder="e.g., Tacos"
+                  placeholder={activeMode === 'home' ? 'e.g., Tacos' : 'e.g., Korean'}
                   required
                   autoFocus
                 />
               </div>
-              <div>
+              {activeMode === 'home' && <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Description (optional)
                 </label>
@@ -467,17 +713,17 @@ export function Dashboard() {
                   rows={3}
                   placeholder="e.g., Beef tacos with all the fixings"
                 />
-              </div>
+              </div>}
               <div className="flex gap-3">
                 <button
                   type="button"
-                  onClick={() => setShowAddMeal(false)}
+                  onClick={closeAddMeal}
                   className="btn btn-secondary flex-1"
                 >
                   Cancel
                 </button>
                 <button type="submit" className="btn btn-primary flex-1">
-                  Add Meal
+                  {activeMode === 'home' ? 'Add Meal' : 'Add Category'}
                 </button>
               </div>
             </form>
@@ -489,7 +735,9 @@ export function Dashboard() {
       {showEditMeal && editingMeal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="card w-full max-w-md">
-            <h3 className="text-xl font-bold mb-4">Edit Meal</h3>
+            <h3 className="text-xl font-bold mb-4">
+              {editingMeal.type === 'category' ? 'Edit Category' : 'Edit Meal'}
+            </h3>
             <form onSubmit={handleUpdateMeal} className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -500,12 +748,12 @@ export function Dashboard() {
                   value={editTitle}
                   onChange={(e) => setEditTitle(e.target.value)}
                   className="input"
-                  placeholder="e.g., Tacos"
+                  placeholder={editingMeal.type === 'category' ? 'e.g., Korean' : 'e.g., Tacos'}
                   required
                   autoFocus
                 />
               </div>
-              <div>
+              {editingMeal.type === 'meal' && <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Description (optional)
                 </label>
@@ -516,7 +764,7 @@ export function Dashboard() {
                   rows={3}
                   placeholder="e.g., Beef tacos with all the fixings"
                 />
-              </div>
+              </div>}
               <div className="flex gap-3">
                 <button
                   type="button"
@@ -540,10 +788,61 @@ export function Dashboard() {
           <div className="card w-full max-w-md max-h-[80vh] overflow-hidden flex flex-col">
             <h3 className="text-xl font-bold mb-4">Create Session</h3>
 
+            <div className="grid grid-cols-2 gap-2 bg-gray-100 rounded-lg p-1 mb-4">
+              <button
+                type="button"
+                onClick={() => changeSessionMode('home')}
+                className={`px-3 py-2 rounded-md text-sm font-medium ${
+                  sessionMode === 'home' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-600'
+                }`}
+              >
+                Cook at home
+              </button>
+              <button
+                type="button"
+                onClick={() => changeSessionMode('takeout')}
+                className={`px-3 py-2 rounded-md text-sm font-medium ${
+                  sessionMode === 'takeout' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-600'
+                }`}
+              >
+                Order out
+              </button>
+            </div>
+
+            {sessionMode === 'takeout' && (
+              <div className="mb-4">
+                <p className="text-sm font-medium text-gray-700 mb-2">Quick picks</p>
+                <div className="flex flex-wrap gap-2">
+                  {TAKEOUT_CATEGORY_SUGGESTIONS.map((suggestion) => {
+                    const existing = meals.find(
+                      (meal) => meal.type === 'category'
+                        && meal.title.toLowerCase() === suggestion.toLowerCase()
+                    );
+                    const selected = existing ? selectedMealIds.includes(existing.id) : false;
+                    return (
+                      <button
+                        key={suggestion}
+                        type="button"
+                        disabled={addingSuggestion === suggestion}
+                        onClick={() => handleTakeoutSuggestion(suggestion, true)}
+                        className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
+                          selected
+                            ? 'bg-orange-100 border-orange-300 text-orange-800'
+                            : 'bg-white border-gray-300 text-gray-700 hover:border-orange-400'
+                        }`}
+                      >
+                        {selected ? `✓ ${suggestion}` : suggestion}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
             {/* Quick Add Meal */}
             <form onSubmit={handleQuickAddMeal} className="mb-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Quick add meal
+                {sessionMode === 'home' ? 'Quick add meal' : 'Quick add category'}
               </label>
               <div className="flex gap-2">
                 <input
@@ -551,7 +850,7 @@ export function Dashboard() {
                   value={quickAddTitle}
                   onChange={(e) => setQuickAddTitle(e.target.value)}
                   className="input flex-1"
-                  placeholder="e.g., Pizza"
+                  placeholder={sessionMode === 'home' ? 'e.g., Pizza' : 'e.g., Korean'}
                 />
                 <button
                   type="submit"
@@ -564,17 +863,22 @@ export function Dashboard() {
             </form>
 
             <p className="text-gray-600 text-sm mb-4">
-              Select meals to include in this session:
+              Select {sessionMode === 'home' ? 'meals' : 'food categories'} to include:
             </p>
 
-            {meals.length > 30 && (
+            {sessionMeals.length > 30 && (
               <div className="bg-yellow-50 text-yellow-700 px-3 py-2 rounded text-sm mb-4">
-                With {meals.length} meals, sessions may take longer to complete.
+                With {sessionMeals.length} options, sessions may take longer to complete.
               </div>
             )}
 
             <div className="flex-1 overflow-y-auto space-y-2 mb-4">
-              {meals.map((meal) => (
+              {sessionMeals.length === 0 && (
+                <p className="text-sm text-gray-500 text-center py-4">
+                  No saved {sessionMode === 'home' ? 'meals' : 'categories'} yet. Add one above.
+                </p>
+              )}
+              {sessionMeals.map((meal) => (
                 <label
                   key={meal.id}
                   className="flex items-center gap-3 p-3 rounded-lg border cursor-pointer hover:bg-gray-50"
@@ -602,7 +906,7 @@ export function Dashboard() {
                 disabled={selectedMealIds.length === 0}
                 className="btn btn-success flex-1"
               >
-                Create ({selectedMealIds.length} meals)
+                Create ({selectedMealIds.length} options)
               </button>
             </div>
           </div>
@@ -612,11 +916,17 @@ export function Dashboard() {
       {/* Confirmation Modal */}
       <ConfirmModal
         isOpen={showDeleteConfirm}
-        title={mealToDelete ? 'Delete Meal?' : `Delete ${selectedForDeletion.length} Meal${selectedForDeletion.length !== 1 ? 's' : ''}?`}
+        title={mealToDelete
+          ? `Delete ${mealToDelete.type === 'category' ? 'Category' : 'Meal'}?`
+          : `Delete ${selectedForDeletion.length} ${activeMode === 'takeout' ? 'Categor' : 'Meal'}${
+              activeMode === 'takeout'
+                ? selectedForDeletion.length === 1 ? 'y' : 'ies'
+                : selectedForDeletion.length !== 1 ? 's' : ''
+            }?`}
         message={
           mealToDelete
             ? `Are you sure you want to delete "${mealToDelete.title}"?`
-            : `Are you sure you want to delete the following meals?\n\n${meals
+            : `Are you sure you want to delete the following ${activeMode === 'takeout' ? 'categories' : 'meals'}?\n\n${meals
                 .filter((m) => selectedForDeletion.includes(m.id))
                 .map((m) => `• ${m.title}`)
                 .join('\n')}`

--- a/client/src/pages/JoinSession.tsx
+++ b/client/src/pages/JoinSession.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { participantApi } from '../api/client';
+import { participantApi, SessionMode } from '../api/client';
 
 export function JoinSession() {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -11,17 +11,15 @@ export function JoinSession() {
   const [error, setError] = useState('');
   const [sessionClosed, setSessionClosed] = useState(false);
   const [participantCount, setParticipantCount] = useState(0);
+  const [mode, setMode] = useState<SessionMode>('home');
 
-  useEffect(() => {
-    checkSession();
-  }, [inviteCode]);
-
-  const checkSession = async () => {
+  const checkSession = useCallback(async () => {
     if (!inviteCode) return;
 
     try {
       const session = await participantApi.getSession(inviteCode);
       setParticipantCount(session.participantCount);
+      setMode(session.mode);
     } catch (err) {
       if (err instanceof Error) {
         if (err.message.includes('ended')) {
@@ -33,7 +31,11 @@ export function JoinSession() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [inviteCode]);
+
+  useEffect(() => {
+    checkSession();
+  }, [checkSession]);
 
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,6 +53,7 @@ export function JoinSession() {
         JSON.stringify({
           participantId: response.participantId,
           displayName: displayName.trim(),
+          mode: response.mode,
           meals: response.meals,
         })
       );
@@ -102,7 +105,9 @@ export function JoinSession() {
         <div className="card">
           <div className="text-center mb-8">
             <h1 className="text-3xl font-bold text-primary-600">MealMatch</h1>
-            <p className="text-gray-600 mt-2">Join the meal voting session</p>
+            <p className="text-gray-600 mt-2">
+              Join the {mode === 'takeout' ? 'order-out' : 'home-meal'} voting session
+            </p>
             <div className="flex items-center justify-center gap-2 mt-4">
               <span className="bg-primary-100 text-primary-700 font-mono font-bold px-4 py-2 rounded-lg text-xl">
                 {inviteCode}

--- a/client/src/pages/QuickSession.test.tsx
+++ b/client/src/pages/QuickSession.test.tsx
@@ -40,7 +40,8 @@ describe('QuickSession', () => {
 
     expect(screen.getByText('MealMatch')).toBeInTheDocument();
     expect(screen.getByLabelText('Your Name')).toBeInTheDocument();
-    expect(screen.getByText('Meal Options')).toBeInTheDocument();
+    expect(screen.getByText('Food Categories')).toBeInTheDocument();
+    expect(screen.getByText('Order out')).toBeInTheDocument();
     expect(screen.getByText('Create Session')).toBeInTheDocument();
   });
 
@@ -69,7 +70,7 @@ describe('QuickSession', () => {
     fireEvent.click(addButton);
 
     // Remove it
-    const removeButtons = screen.getAllByLabelText('Remove meal');
+    const removeButtons = screen.getAllByLabelText('Remove option');
     fireEvent.click(removeButtons[0]);
 
     const inputs = screen.getAllByPlaceholderText(/Option \d+/);
@@ -79,7 +80,7 @@ describe('QuickSession', () => {
   it('should not allow removing the last meal input', () => {
     renderQuickSession();
 
-    const removeButtons = screen.queryAllByLabelText('Remove meal');
+    const removeButtons = screen.queryAllByLabelText('Remove option');
     expect(removeButtons).toHaveLength(0);
   });
 
@@ -104,7 +105,7 @@ describe('QuickSession', () => {
     fireEvent.click(createButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Please add at least one meal option')).toBeInTheDocument();
+      expect(screen.getByText('Please add at least one food category')).toBeInTheDocument();
     });
   });
 
@@ -113,13 +114,14 @@ describe('QuickSession', () => {
       session: {
         id: 'session-123',
         inviteCode: 'ABC123',
-        status: 'open'
+        status: 'open',
+        mode: 'takeout' as const,
       },
       participantId: 'participant-123',
       creatorToken: 'token-123',
       meals: [
-        { id: 'meal-1', title: 'Pizza', description: null, sessionMealId: 'sm-1' },
-        { id: 'meal-2', title: 'Tacos', description: null, sessionMealId: 'sm-2' }
+        { id: 'meal-1', title: 'Pizza', description: null, type: 'category' as const, sessionMealId: 'sm-1' },
+        { id: 'meal-2', title: 'Tacos', description: null, type: 'category' as const, sessionMealId: 'sm-2' }
       ]
     };
 
@@ -140,11 +142,13 @@ describe('QuickSession', () => {
     await waitFor(() => {
       expect(client.quickSessionApi.create).toHaveBeenCalledWith(
         'Test User',
-        [{ title: 'Pizza', description: undefined }]
+        [{ title: 'Pizza', description: undefined }],
+        'takeout'
       );
       expect(sessionStorage.getItem('sessionId')).toBe('session-123');
       expect(sessionStorage.getItem('participantId')).toBe('participant-123');
       expect(sessionStorage.getItem('creatorToken')).toBe('token-123');
+      expect(sessionStorage.getItem('sessionMode')).toBe('takeout');
       expect(mockNavigate).toHaveBeenCalledWith('/session/session-123/share');
     });
   });
@@ -168,5 +172,30 @@ describe('QuickSession', () => {
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument();
     });
+  });
+
+  it('adds takeout suggestions without creating duplicate option names', () => {
+    renderQuickSession();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pizza' }));
+    expect(screen.getByPlaceholderText('Option 1')).toHaveValue('Pizza');
+
+    fireEvent.click(screen.getByRole('button', { name: /Pizza/ }));
+    expect(screen.getAllByPlaceholderText(/Option \d+/)).toHaveLength(1);
+  });
+
+  it('preserves separate drafts when switching between takeout and home', () => {
+    renderQuickSession();
+
+    fireEvent.change(screen.getByPlaceholderText('Option 1'), {
+      target: { value: 'Sushi' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cook at home' }));
+    fireEvent.change(screen.getByPlaceholderText('Option 1'), {
+      target: { value: 'Lasagna' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Order out' }));
+
+    expect(screen.getByPlaceholderText('Option 1')).toHaveValue('Sushi');
   });
 });

--- a/client/src/pages/QuickSession.tsx
+++ b/client/src/pages/QuickSession.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { quickSessionApi } from '../api/client';
+import { quickSessionApi, SessionMode } from '../api/client';
+import { TAKEOUT_CATEGORY_SUGGESTIONS } from '../constants/takeoutCategories';
 
 interface MealInput {
   id: string;
@@ -10,16 +11,28 @@ interface MealInput {
 export default function QuickSession() {
   const navigate = useNavigate();
   const [creatorName, setCreatorName] = useState('');
-  const [meals, setMeals] = useState<MealInput[]>([
-    { id: crypto.randomUUID(), title: '' }
-  ]);
+  const [mode, setMode] = useState<SessionMode>('takeout');
+  const [drafts, setDrafts] = useState<Record<SessionMode, MealInput[]>>({
+    home: [{ id: crypto.randomUUID(), title: '' }],
+    takeout: [{ id: crypto.randomUUID(), title: '' }],
+  });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const mealInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+  const meals = drafts[mode];
+
+  const updateCurrentDraft = (
+    updater: (current: MealInput[]) => MealInput[]
+  ) => {
+    setDrafts((current) => ({
+      ...current,
+      [mode]: updater(current[mode]),
+    }));
+  };
 
   const addMeal = () => {
     const newMeal = { id: crypto.randomUUID(), title: '' };
-    setMeals([...meals, newMeal]);
+    updateCurrentDraft((current) => [...current, newMeal]);
     // Focus the new input after render
     setTimeout(() => {
       mealInputRefs.current.get(newMeal.id)?.focus();
@@ -28,12 +41,31 @@ export default function QuickSession() {
 
   const removeMeal = (id: string) => {
     if (meals.length > 1) {
-      setMeals(meals.filter(m => m.id !== id));
+      updateCurrentDraft((current) => current.filter(m => m.id !== id));
     }
   };
 
   const updateMeal = (id: string, value: string) => {
-    setMeals(meals.map(m => m.id === id ? { ...m, title: value } : m));
+    updateCurrentDraft((current) =>
+      current.map(m => m.id === id ? { ...m, title: value } : m)
+    );
+  };
+
+  const addSuggestedCategory = (title: string) => {
+    if (meals.some((meal) => meal.title.trim().toLowerCase() === title.toLowerCase())) {
+      return;
+    }
+
+    const emptyMeal = meals.find((meal) => !meal.title.trim());
+    if (emptyMeal) {
+      updateMeal(emptyMeal.id, title);
+      return;
+    }
+
+    updateCurrentDraft((current) => [
+      ...current,
+      { id: crypto.randomUUID(), title },
+    ]);
   };
 
   const handleMealKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, mealId: string, index: number) => {
@@ -62,7 +94,15 @@ export default function QuickSession() {
 
     const validMeals = meals.filter(m => m.title.trim());
     if (validMeals.length === 0) {
-      setError('Please add at least one meal option');
+      setError(`Please add at least one ${mode === 'home' ? 'meal' : 'food category'}`);
+      return;
+    }
+
+    const uniqueTitles = new Set(
+      validMeals.map((meal) => meal.title.trim().toLowerCase())
+    );
+    if (uniqueTitles.size !== validMeals.length) {
+      setError('Option names must be unique');
       return;
     }
 
@@ -72,8 +112,10 @@ export default function QuickSession() {
       const response = await quickSessionApi.create(
         creatorName.trim(),
         validMeals.map(m => ({
-          title: m.title.trim()
-        }))
+          title: m.title.trim(),
+          description: undefined,
+        })),
+        mode
       );
 
       // Store session info in the format SwipeSession expects
@@ -82,12 +124,14 @@ export default function QuickSession() {
         JSON.stringify({
           participantId: response.participantId,
           displayName: creatorName.trim(),
-          meals: response.meals
+          mode: response.session.mode,
+          meals: response.meals,
         })
       );
       sessionStorage.setItem('sessionId', response.session.id);
       sessionStorage.setItem('participantId', response.participantId);
       sessionStorage.setItem('inviteCode', response.session.inviteCode);
+      sessionStorage.setItem('sessionMode', response.session.mode);
       if (response.creatorToken) {
         sessionStorage.setItem('creatorToken', response.creatorToken);
       }
@@ -107,7 +151,7 @@ export default function QuickSession() {
         <div className="mb-8">
           <h1 className="text-4xl font-bold text-gray-900 mb-2">MealMatch</h1>
           <p className="text-gray-600">
-            Create a quick session and start swiping on meal ideas with your group
+            Start a quick vote for takeout or a meal at home
           </p>
         </div>
 
@@ -118,6 +162,30 @@ export default function QuickSession() {
         ) : null}
 
         <div className="space-y-6">
+          <div>
+            <span className="block text-sm font-medium text-gray-700 mb-2">What are you deciding?</span>
+            <div className="grid grid-cols-2 gap-2 bg-gray-100 rounded-lg p-1">
+              <button
+                type="button"
+                onClick={() => setMode('takeout')}
+                className={`px-4 py-3 rounded-md font-medium ${
+                  mode === 'takeout' ? 'bg-white shadow-sm text-orange-700' : 'text-gray-600'
+                }`}
+              >
+                Order out
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode('home')}
+                className={`px-4 py-3 rounded-md font-medium ${
+                  mode === 'home' ? 'bg-white shadow-sm text-orange-700' : 'text-gray-600'
+                }`}
+              >
+                Cook at home
+              </button>
+            </div>
+          </div>
+
           <div>
             <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
               Your Name
@@ -140,8 +208,31 @@ export default function QuickSession() {
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Meal Options
+              {mode === 'home' ? 'Meal Options' : 'Food Categories'}
             </label>
+            {mode === 'takeout' && (
+              <div className="flex flex-wrap gap-2 mb-4">
+                {TAKEOUT_CATEGORY_SUGGESTIONS.map((suggestion) => {
+                  const selected = meals.some(
+                    (meal) => meal.title.trim().toLowerCase() === suggestion.toLowerCase()
+                  );
+                  return (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      onClick={() => addSuggestedCategory(suggestion)}
+                      className={`px-3 py-1.5 rounded-full border text-sm transition-colors ${
+                        selected
+                          ? 'bg-orange-100 border-orange-300 text-orange-800'
+                          : 'bg-white border-gray-300 text-gray-700 hover:border-orange-400'
+                      }`}
+                    >
+                      {selected ? `✓ ${suggestion}` : suggestion}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
             <div className="space-y-3">
               {meals.map((meal, index) => (
                 <div key={meal.id} className="flex gap-2">
@@ -161,7 +252,7 @@ export default function QuickSession() {
                     <button
                       onClick={() => removeMeal(meal.id)}
                       className="px-3 py-3 text-red-600 hover:bg-red-50 rounded-lg transition-colors text-xl"
-                      aria-label="Remove meal"
+                      aria-label="Remove option"
                     >
                       ×
                     </button>

--- a/client/src/pages/Results.test.tsx
+++ b/client/src/pages/Results.test.tsx
@@ -6,6 +6,9 @@ import { participantApi } from '../api/client';
 
 // Mock the API
 vi.mock('../api/client', () => ({
+  ApiException: class ApiException extends Error {
+    existingId?: string;
+  },
   participantApi: {
     getResults: vi.fn(),
     getSessionStatus: vi.fn(),
@@ -52,10 +55,12 @@ describe('Results - Update Choices', () => {
     // Mock waiting results
     (participantApi.getResults as any).mockResolvedValue({
       status: 'waiting',
+      mode: 'home',
       results: [],
     });
 
     (participantApi.getSessionStatus as any).mockResolvedValue({
+      mode: 'home',
       participants: [
         { id: 'participant123', displayName: 'John', submitted: true },
       ],
@@ -81,10 +86,12 @@ describe('Results - Update Choices', () => {
     // Mock waiting results
     (participantApi.getResults as any).mockResolvedValue({
       status: 'waiting',
+      mode: 'home',
       results: [],
     });
 
     (participantApi.getSessionStatus as any).mockResolvedValue({
+      mode: 'home',
       participants: [
         { id: 'participant123', displayName: 'John', submitted: true },
       ],
@@ -114,10 +121,12 @@ describe('Results - Update Choices', () => {
     // Mock waiting results
     (participantApi.getResults as any).mockResolvedValue({
       status: 'waiting',
+      mode: 'home',
       results: [],
     });
 
     (participantApi.getSessionStatus as any).mockResolvedValue({
+      mode: 'home',
       participants: [
         { id: 'participant123', displayName: 'John', submitted: true },
       ],
@@ -151,6 +160,7 @@ describe('Results - Update Choices', () => {
     // Mock closed results
     (participantApi.getResults as any).mockResolvedValue({
       status: 'closed',
+      mode: 'home',
       results: [
         {
           mealId: '1',

--- a/client/src/pages/Results.tsx
+++ b/client/src/pages/Results.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { participantApi, ResultsResponse, MatchResult, mealsApi } from '../api/client';
+import { participantApi, ResultsResponse, MatchResult, mealsApi, ApiException } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
 
 interface Participant {
@@ -99,9 +99,20 @@ export function Results() {
 
     setSavingMeals(true);
     try {
-      // Save all meals to the user's library
+      const isTakeout = results.mode === 'takeout';
+      // Save all quick-session options to the matching library.
       for (const result of results.results) {
-        await mealsApi.create(result.title, result.description || undefined);
+        try {
+          if (isTakeout) {
+            await mealsApi.create(result.title, undefined, 'category');
+          } else {
+            await mealsApi.create(result.title, result.description || undefined);
+          }
+        } catch (err) {
+          if (!(err instanceof ApiException && err.existingId)) {
+            throw err;
+          }
+        }
       }
 
       // Clear creator token
@@ -112,7 +123,7 @@ export function Results() {
       // Navigate to dashboard
       navigate('/dashboard');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save meals');
+      setError(err instanceof Error ? err.message : 'Failed to save options');
     } finally {
       setSavingMeals(false);
     }
@@ -369,13 +380,15 @@ export function Results() {
           </section>
         )}
 
-        {/* Save meals prompt for anonymous creators */}
+        {/* Save options prompt for anonymous creators */}
         {isCreator && showSavePrompt && !user ? (
           <div className="card bg-orange-50 border-2 border-orange-500 mt-8">
             <div className="text-center">
-              <h3 className="font-bold text-lg">Save these meals?</h3>
+              <h3 className="font-bold text-lg">
+                Save these {results.mode === 'takeout' ? 'food categories' : 'meals'}?
+              </h3>
               <p className="text-gray-600 mt-1 mb-4">
-                Create an account to save these meals to your library and host more sessions!
+                Create an account to build a reusable library and host more sessions!
               </p>
               <div className="flex gap-3 justify-center">
                 <button
@@ -395,13 +408,15 @@ export function Results() {
           </div>
         ) : null}
 
-        {/* Save meals for logged-in creators */}
+        {/* Save options for logged-in creators */}
         {isCreator && showSavePrompt && user ? (
           <div className="card bg-green-50 border-2 border-green-500 mt-8">
             <div className="text-center">
-              <h3 className="font-bold text-lg">Save these meals to your library?</h3>
+              <h3 className="font-bold text-lg">
+                Save these {results.mode === 'takeout' ? 'food categories' : 'meals'} to your library?
+              </h3>
               <p className="text-gray-600 mt-1 mb-4">
-                Add all meals from this session to your permanent collection.
+                Add all options from this session to your permanent collection.
               </p>
               <div className="flex gap-3 justify-center">
                 <button
@@ -415,7 +430,9 @@ export function Results() {
                   disabled={savingMeals}
                   className="px-6 py-2 bg-green-600 hover:bg-green-700 disabled:bg-gray-400 text-white rounded-lg transition-colors"
                 >
-                  {savingMeals ? 'Saving...' : 'Save Meals'}
+                  {savingMeals
+                    ? 'Saving...'
+                    : results.mode === 'takeout' ? 'Save Categories' : 'Save Meals'}
                 </button>
               </div>
             </div>
@@ -428,7 +445,7 @@ export function Results() {
             <div className="text-center">
               <h3 className="font-bold text-lg">Want to host your own sessions?</h3>
               <p className="text-gray-600 mt-1 mb-4">
-                Create an account to build your meal collection and invite friends.
+                Create an account to build your food library and invite friends.
               </p>
               <Link to="/register" className="btn btn-primary">
                 Create Account

--- a/client/src/pages/SessionView.tsx
+++ b/client/src/pages/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { sessionsApi, SessionDetails, MatchResult } from '../api/client';
 import ConfirmModal from '../components/ConfirmModal';
@@ -11,11 +11,7 @@ export function SessionView() {
   const [copied, setCopied] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
-  useEffect(() => {
-    loadSession();
-  }, [sessionId]);
-
-  const loadSession = async () => {
+  const loadSession = useCallback(async () => {
     if (!sessionId) return;
 
     try {
@@ -26,7 +22,11 @@ export function SessionView() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [sessionId]);
+
+  useEffect(() => {
+    loadSession();
+  }, [loadSession]);
 
   const handleCopyLink = async () => {
     if (!session) return;
@@ -118,6 +118,9 @@ export function SessionView() {
           >
             {session.status}
           </span>
+          <span className="px-3 py-1 rounded text-sm font-medium bg-orange-50 text-orange-700">
+            {session.mode === 'takeout' ? 'Order out' : 'Cook at home'}
+          </span>
         </div>
       </header>
 
@@ -145,7 +148,7 @@ export function SessionView() {
             </a>
           </div>
           <p className="text-sm text-gray-500 mt-2">
-            Share this link with your group to let them vote on meals
+            Share this link with your group to let them vote on options
           </p>
         </section>
 
@@ -223,9 +226,9 @@ export function SessionView() {
           </section>
         )}
 
-        {/* Meals in Session */}
+        {/* Options in Session */}
         <section className="card">
-          <h2 className="text-xl font-bold mb-4">Meals in Session ({session.meals.length})</h2>
+          <h2 className="text-xl font-bold mb-4">Options in Session ({session.meals.length})</h2>
           <div className="grid gap-3 sm:grid-cols-2">
             {session.meals.map((meal) => (
               <div key={meal.id} className="border rounded-lg p-3">

--- a/client/src/pages/ShareSession.tsx
+++ b/client/src/pages/ShareSession.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import type { SessionMode } from '../api/client';
 
 export function ShareSession() {
   const { sessionId } = useParams<{ sessionId: string }>();
   const navigate = useNavigate();
   const [inviteCode, setInviteCode] = useState('');
   const [copied, setCopied] = useState(false);
+  const [mode, setMode] = useState<SessionMode>('home');
 
   useEffect(() => {
     const code = sessionStorage.getItem('inviteCode');
     if (code) {
       setInviteCode(code);
+    }
+    const storedMode = sessionStorage.getItem('sessionMode');
+    if (storedMode === 'home' || storedMode === 'takeout') {
+      setMode(storedMode);
     }
   }, []);
 
@@ -65,7 +71,9 @@ export function ShareSession() {
             </svg>
           </div>
           <h1 className="text-2xl font-bold text-gray-900 mb-2">Session Created!</h1>
-          <p className="text-gray-600">Share this link with your group</p>
+          <p className="text-gray-600">
+            Share this {mode === 'takeout' ? 'order-out' : 'cook-at-home'} vote with your group
+          </p>
         </div>
 
         <div className="mb-6">

--- a/client/src/pages/SwipeSession.tsx
+++ b/client/src/pages/SwipeSession.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { participantApi } from '../api/client';
+import type { SessionMode } from '../api/client';
 import { SwipeDeck } from '../components/SwipeDeck';
 import { useSwipeProgress } from '../hooks/useLocalStorage';
 
 interface SessionData {
   participantId: string;
   displayName: string;
+  mode?: SessionMode;
   meals: Array<{
     id: string;
     title: string;
@@ -34,11 +36,7 @@ export function SwipeSession() {
     displayName
   );
 
-  useEffect(() => {
-    loadSessionData();
-  }, [sessionId]);
-
-  const loadSessionData = () => {
+  const loadSessionData = useCallback(() => {
     if (!sessionId) return;
 
     // Try to get session data from storage
@@ -49,7 +47,11 @@ export function SwipeSession() {
       // No session data - redirect to join
       setError('Session data not found. Please rejoin the session.');
     }
-  };
+  }, [sessionId]);
+
+  useEffect(() => {
+    loadSessionData();
+  }, [loadSessionData]);
 
   const handleSwipe = (
     _mealId: string,
@@ -181,7 +183,11 @@ export function SwipeSession() {
         <div className="text-center mb-6">
           <h1 className="text-lg font-bold text-primary-600">MealMatch</h1>
           <p className="text-gray-600 text-sm mt-1">
-            {editMode ? `Update your choices, ${sessionData.displayName}!` : `Hey ${sessionData.displayName}! Swipe right on meals you'd like.`}
+            {editMode
+              ? `Update your choices, ${sessionData.displayName}!`
+              : `Hey ${sessionData.displayName}! Swipe right on ${
+                  sessionData.mode === 'takeout' ? 'food categories' : 'meals'
+                } you'd like.`}
           </p>
 
           {/* Dev toggle for swipe hint styles */}

--- a/e2e/authenticated-host.spec.ts
+++ b/e2e/authenticated-host.spec.ts
@@ -48,7 +48,7 @@ test.describe('Authenticated Host Flow', () => {
     await expect(page.locator('text=Select meals to include')).toBeVisible();
 
     // All meals are pre-selected, just create the session
-    await page.click('button:has-text("Create (3 meals)")');
+    await page.click('button:has-text("Create (3 options)")');
 
     // Then: Redirected to session view
     await expect(page).toHaveURL(/\/session\/.*/);
@@ -131,11 +131,11 @@ test.describe('Authenticated Host Flow', () => {
     await expect(sessionModal.locator('label:has-text("Existing Meal") input[type="checkbox"]')).toBeChecked();
 
     // Create the session
-    await page.click('button:has-text("Create (2 meals)")');
+    await page.click('button:has-text("Create (2 options)")');
 
     // Then: Session is created with both meals
     await expect(page).toHaveURL(/\/session\/.*/);
-    await expect(page.locator('text=Meals in Session (2)')).toBeVisible();
+    await expect(page.locator('text=Options in Session (2)')).toBeVisible();
   });
 
   test('host can login and access previous meals', async ({ page }) => {
@@ -181,7 +181,7 @@ test.describe('Authenticated Host Flow', () => {
     await addMeal(page, 'History Test Meal');
 
     await page.click('button:has-text("Create Session")');
-    await page.click('button:has-text("Create (1 meals)")');
+    await page.click('button:has-text("Create (1 options)")');
 
     // Should be on session view now
     await expect(page).toHaveURL(/\/session\/.*/);

--- a/e2e/food-modes.spec.ts
+++ b/e2e/food-modes.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Home and takeout session modes', () => {
+  test('anonymous quick sessions default to takeout suggestions', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('Food Categories')).toBeVisible();
+    await page.getByLabel('Your Name').fill('Takeout Tester');
+    await page.getByRole('button', { name: 'Pizza' }).click();
+    await expect(page.getByPlaceholder('Option 1')).toHaveValue('Pizza');
+
+    await page.getByRole('button', { name: 'Create Session' }).click();
+    await expect(page).toHaveURL(/\/session\/[^/]+\/share/);
+    await expect(page.getByText('order-out vote')).toBeVisible();
+  });
+
+  test('authenticated takeout categories persist and create a takeout session', async ({ page }) => {
+    const email = `takeout-${Date.now()}@example.com`;
+
+    await page.goto('/register');
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password', { exact: true }).fill('password123');
+    await page.getByLabel('Confirm Password').fill('password123');
+    await page.getByRole('button', { name: 'Create Account' }).click();
+    await expect(page).toHaveURL('/dashboard');
+
+    await page.getByRole('button', { name: 'Takeout' }).click();
+    await page.getByRole('button', { name: 'Start with popular categories' }).click();
+    const onboardingModal = page.locator('.card:has(h3:has-text("Start with popular categories"))');
+    const mexican = onboardingModal.getByRole('checkbox', { name: 'Mexican' });
+    await mexican.check();
+    await expect(mexican).toBeChecked();
+    await mexican.uncheck();
+    await expect(mexican).not.toBeChecked();
+    await mexican.check();
+    await onboardingModal.getByRole('button', { name: 'Add selected (1)' }).click();
+    await expect(page.getByText('Mexican')).toBeVisible();
+
+    await page.reload();
+    await page.getByRole('button', { name: 'Takeout' }).click();
+    await expect(page.getByText('Mexican')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Create Session' }).click();
+    await expect(page.getByText('Quick add category')).toBeVisible();
+    await page.getByRole('button', { name: 'Create (1 options)' }).click();
+
+    await expect(page).toHaveURL(/\/session\/[^/]+$/);
+    await expect(page.getByText('Order out')).toBeVisible();
+    await expect(page.getByText('Options in Session (1)')).toBeVisible();
+
+    await page.goto('/dashboard');
+    await page.getByRole('button', { name: 'Takeout' }).click();
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Delete Selected (1)' }).click();
+    await page.getByRole('button', { name: 'Confirm' }).click();
+    await expect(page.getByText('No takeout categories yet. Add your favorites to get started!')).toBeVisible();
+    await expect(page.getByText('Build your takeout list')).not.toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+
+const e2eDatabasePath = path.resolve('test-results', `e2e-database-${process.pid}.db`);
 
 export default defineConfig({
   testDir: './e2e',
@@ -21,7 +24,11 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: process.env.PLAYWRIGHT_REUSE_SERVER === '1',
     timeout: 120 * 1000,
+    env: {
+      DATABASE_PATH: e2eDatabasePath,
+      SESSION_SECRET: 'mealmatch-e2e-session-secret',
+    },
   },
 });

--- a/server/src/db/schema.test.ts
+++ b/server/src/db/schema.test.ts
@@ -1,0 +1,74 @@
+import fs from 'fs';
+import path from 'path';
+import initSqlJs from 'sql.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const testDatabasePath = path.join(__dirname, '../../data/schema-migration-test.db');
+
+describe('database schema migrations', () => {
+  afterEach(() => {
+    delete process.env.DATABASE_PATH;
+    vi.resetModules();
+    if (fs.existsSync(testDatabasePath)) {
+      fs.rmSync(testDatabasePath);
+    }
+  });
+
+  it('migrates existing meals and sessions to the mode-aware schema', async () => {
+    const SQL = await initSqlJs();
+    const legacyDatabase = new SQL.Database();
+    legacyDatabase.run(`
+      CREATE TABLE meals (
+        id TEXT PRIMARY KEY,
+        host_id TEXT NOT NULL,
+        type TEXT,
+        archived INTEGER DEFAULT 0
+      );
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY
+      );
+      CREATE TABLE hosts (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL,
+        password_hash TEXT NOT NULL
+      );
+      INSERT INTO meals (id, host_id, type, archived)
+      VALUES ('meal-1', 'host-1', NULL, 0);
+      INSERT INTO hosts (id, email, password_hash)
+      VALUES ('host-1', 'host@example.com', 'hash');
+      INSERT INTO hosts (id, email, password_hash)
+      VALUES ('host-2', 'category-host@example.com', 'hash');
+      INSERT INTO meals (id, host_id, type, archived)
+      VALUES ('category-1', 'host-2', 'category', 0);
+      INSERT INTO sessions (id) VALUES ('session-1');
+    `);
+    fs.mkdirSync(path.dirname(testDatabasePath), { recursive: true });
+    fs.writeFileSync(testDatabasePath, Buffer.from(legacyDatabase.export()));
+    legacyDatabase.close();
+
+    process.env.DATABASE_PATH = testDatabasePath;
+    vi.resetModules();
+    const { initializeDatabase, getOne } = await import('./schema');
+    const migratedDatabase = await initializeDatabase();
+
+    const sessionColumns = migratedDatabase.exec('PRAGMA table_info(sessions)')[0].values;
+    expect(sessionColumns.some((column) => column[1] === 'mode')).toBe(true);
+    const hostColumns = migratedDatabase.exec('PRAGMA table_info(hosts)')[0].values;
+    expect(hostColumns.some((column) => column[1] === 'takeout_onboarding_dismissed')).toBe(true);
+    expect(getOne<{ mode: string }>('SELECT mode FROM sessions WHERE id = ?', ['session-1'])?.mode)
+      .toBe('home');
+    expect(getOne<{ dismissed: number }>(
+      'SELECT takeout_onboarding_dismissed AS dismissed FROM hosts WHERE id = ?',
+      ['host-1']
+    )?.dismissed).toBe(0);
+    expect(getOne<{ dismissed: number }>(
+      'SELECT takeout_onboarding_dismissed AS dismissed FROM hosts WHERE id = ?',
+      ['host-2']
+    )?.dismissed).toBe(1);
+    expect(getOne<{ type: string }>('SELECT type FROM meals WHERE id = ?', ['meal-1'])?.type)
+      .toBe('meal');
+
+    const indexes = migratedDatabase.exec('PRAGMA index_list(meals)')[0].values;
+    expect(indexes.some((index) => index[1] === 'idx_meals_host_type_archived')).toBe(true);
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -32,20 +32,46 @@ export async function initializeDatabase(): Promise<Database> {
 }
 
 function runMigrations(database: Database): void {
-  // Add temporary and creator_token columns to meals table if they don't exist
-  try {
+  if (!columnExists(database, 'meals', 'temporary')) {
     database.run('ALTER TABLE meals ADD COLUMN temporary INTEGER DEFAULT 0');
-  } catch (e) {
-    // Column already exists, ignore
   }
 
-  try {
+  if (!columnExists(database, 'meals', 'creator_token')) {
     database.run('ALTER TABLE meals ADD COLUMN creator_token TEXT');
-  } catch (e) {
-    // Column already exists, ignore
   }
+
+  if (!columnExists(database, 'sessions', 'mode')) {
+    database.run("ALTER TABLE sessions ADD COLUMN mode TEXT NOT NULL DEFAULT 'home'");
+  }
+
+  if (!columnExists(database, 'hosts', 'takeout_onboarding_dismissed')) {
+    database.run('ALTER TABLE hosts ADD COLUMN takeout_onboarding_dismissed INTEGER NOT NULL DEFAULT 0');
+  }
+
+  database.run("UPDATE meals SET type = 'meal' WHERE type IS NULL OR TRIM(type) = ''");
+  database.run(`
+    UPDATE hosts
+    SET takeout_onboarding_dismissed = 1
+    WHERE EXISTS (
+      SELECT 1
+      FROM meals
+      WHERE meals.host_id = hosts.id AND meals.type = 'category'
+    )
+  `);
+  database.run(`
+    CREATE INDEX IF NOT EXISTS idx_meals_host_type_archived
+    ON meals(host_id, type, archived)
+  `);
 
   saveDatabase();
+}
+
+function columnExists(database: Database, table: string, column: string): boolean {
+  const result = database.exec(`PRAGMA table_info(${table})`);
+  if (result.length === 0) return false;
+
+  const nameIndex = result[0].columns.indexOf('name');
+  return result[0].values.some((row) => row[nameIndex] === column);
 }
 
 function createTables(database: Database): void {
@@ -55,6 +81,7 @@ function createTables(database: Database): void {
       id TEXT PRIMARY KEY,
       email TEXT UNIQUE NOT NULL,
       password_hash TEXT NOT NULL,
+      takeout_onboarding_dismissed INTEGER NOT NULL DEFAULT 0,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );
 
@@ -78,6 +105,7 @@ function createTables(database: Database): void {
       host_id TEXT NOT NULL REFERENCES hosts(id),
       invite_code TEXT UNIQUE NOT NULL,
       status TEXT DEFAULT 'open',
+      mode TEXT NOT NULL DEFAULT 'home',
       selected_meal_id TEXT REFERENCES meals(id),
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       closed_at DATETIME
@@ -121,6 +149,7 @@ function createTables(database: Database): void {
 
     -- Create indexes for better query performance
     CREATE INDEX IF NOT EXISTS idx_meals_host_id ON meals(host_id);
+    CREATE INDEX IF NOT EXISTS idx_meals_host_type_archived ON meals(host_id, type, archived);
     CREATE INDEX IF NOT EXISTS idx_sessions_host_id ON sessions(host_id);
     CREATE INDEX IF NOT EXISTS idx_sessions_invite_code ON sessions(invite_code);
     CREATE INDEX IF NOT EXISTS idx_session_meals_session_id ON session_meals(session_id);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import { runQuery, getOne } from '../db/schema';
-import { Host, RegisterRequest, LoginRequest } from '../types';
+import { Host, RegisterRequest, LoginRequest, UpdateHostPreferencesRequest } from '../types';
 import { requireAuth } from '../middleware/auth';
 
 const router = Router();
@@ -44,6 +44,7 @@ router.post('/register', async (req, res) => {
     res.status(201).json({
       id,
       email: email.toLowerCase(),
+      takeoutOnboardingDismissed: false,
     });
   } catch (error) {
     console.error('Register error:', error);
@@ -63,7 +64,7 @@ router.post('/login', async (req, res) => {
 
     // Find host by email
     const host = getOne<Host>(
-      'SELECT id, email, password_hash FROM hosts WHERE email = ?',
+      'SELECT id, email, password_hash, takeout_onboarding_dismissed FROM hosts WHERE email = ?',
       [email.toLowerCase()]
     );
 
@@ -85,6 +86,7 @@ router.post('/login', async (req, res) => {
     res.json({
       id: host.id,
       email: host.email,
+      takeoutOnboardingDismissed: Boolean(host.takeout_onboarding_dismissed),
     });
   } catch (error) {
     console.error('Login error:', error);
@@ -108,7 +110,7 @@ router.post('/logout', (req, res) => {
 router.get('/me', requireAuth, (req, res) => {
   try {
     const host = getOne<Host>(
-      'SELECT id, email, created_at FROM hosts WHERE id = ?',
+      'SELECT id, email, created_at, takeout_onboarding_dismissed FROM hosts WHERE id = ?',
       [req.session.hostId]
     );
 
@@ -121,9 +123,47 @@ router.get('/me', requireAuth, (req, res) => {
       id: host.id,
       email: host.email,
       createdAt: host.created_at,
+      takeoutOnboardingDismissed: Boolean(host.takeout_onboarding_dismissed),
     });
   } catch (error) {
     console.error('Get me error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// PATCH /api/auth/preferences - Persist host-level UI preferences
+router.patch('/preferences', requireAuth, (req, res) => {
+  try {
+    const { takeoutOnboardingDismissed } = req.body as UpdateHostPreferencesRequest;
+
+    if (typeof takeoutOnboardingDismissed !== 'boolean') {
+      res.status(400).json({ error: 'takeoutOnboardingDismissed must be a boolean' });
+      return;
+    }
+
+    runQuery(
+      'UPDATE hosts SET takeout_onboarding_dismissed = ? WHERE id = ?',
+      [takeoutOnboardingDismissed ? 1 : 0, req.session.hostId]
+    );
+
+    const host = getOne<Host>(
+      'SELECT id, email, created_at, takeout_onboarding_dismissed FROM hosts WHERE id = ?',
+      [req.session.hostId]
+    );
+
+    if (!host) {
+      res.status(404).json({ error: 'Host not found' });
+      return;
+    }
+
+    res.json({
+      id: host.id,
+      email: host.email,
+      createdAt: host.created_at,
+      takeoutOnboardingDismissed: Boolean(host.takeout_onboarding_dismissed),
+    });
+  } catch (error) {
+    console.error('Update preferences error:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/server/src/routes/meals.ts
+++ b/server/src/routes/meals.ts
@@ -1,10 +1,18 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { runQuery, getOne, getAll } from '../db/schema';
-import { Meal, CreateMealRequest } from '../types';
+import { Meal, MealType, CreateMealRequest } from '../types';
 import { requireAuth } from '../middleware/auth';
 
 const router = Router();
+
+const libraryTypes: MealType[] = ['meal', 'category'];
+
+function getRequestedType(value: unknown): MealType | undefined {
+  return typeof value === 'string' && ['meal', 'category', 'restaurant'].includes(value)
+    ? value as MealType
+    : undefined;
+}
 
 // All meal routes require authentication
 router.use(requireAuth);
@@ -12,12 +20,22 @@ router.use(requireAuth);
 // GET /api/meals - List host's meals (excludes archived)
 router.get('/', (req, res) => {
   try {
+    const requestedType = getRequestedType(req.query.type);
+    if (req.query.type !== undefined && !requestedType) {
+      res.status(400).json({ error: 'Invalid meal type' });
+      return;
+    }
+
+    const typeFilter = requestedType ? ' AND type = ?' : '';
+    const params = requestedType
+      ? [req.session.hostId, requestedType]
+      : [req.session.hostId];
     const meals = getAll<Meal>(
       `SELECT id, title, description, type, archived, pick_count, created_at
        FROM meals
-       WHERE host_id = ? AND archived = 0
+       WHERE host_id = ? AND archived = 0${typeFilter}
        ORDER BY created_at DESC`,
-      [req.session.hostId]
+      params
     );
 
     res.json(meals.map(meal => ({
@@ -37,12 +55,22 @@ router.get('/', (req, res) => {
 // GET /api/meals/all - List all host's meals including archived
 router.get('/all', (req, res) => {
   try {
+    const requestedType = getRequestedType(req.query.type);
+    if (req.query.type !== undefined && !requestedType) {
+      res.status(400).json({ error: 'Invalid meal type' });
+      return;
+    }
+
+    const typeFilter = requestedType ? ' AND type = ?' : '';
+    const params = requestedType
+      ? [req.session.hostId, requestedType]
+      : [req.session.hostId];
     const meals = getAll<Meal>(
       `SELECT id, title, description, type, archived, pick_count, created_at
        FROM meals
-       WHERE host_id = ?
+       WHERE host_id = ?${typeFilter}
        ORDER BY created_at DESC`,
-      [req.session.hostId]
+      params
     );
 
     res.json(meals.map(meal => ({
@@ -63,25 +91,53 @@ router.get('/all', (req, res) => {
 // POST /api/meals - Create meal
 router.post('/', (req, res) => {
   try {
-    const { title, description } = req.body as CreateMealRequest;
+    const { title, description, type = 'meal' } = req.body as CreateMealRequest;
 
     if (!title || title.trim().length === 0) {
       res.status(400).json({ error: 'Title is required' });
       return;
     }
 
+    if (!libraryTypes.includes(type)) {
+      res.status(400).json({ error: 'Type must be meal or category' });
+      return;
+    }
+
+    const normalizedTitle = title.trim();
+    const existing = getOne<Meal>(
+      `SELECT id FROM meals
+       WHERE host_id = ? AND type = ? AND archived = 0 AND LOWER(title) = LOWER(?)`,
+      [req.session.hostId, type, normalizedTitle]
+    );
+
+    if (existing) {
+      res.status(409).json({
+        error: `A ${type === 'category' ? 'food category' : 'meal'} with this name already exists`,
+        existingId: existing.id,
+      });
+      return;
+    }
+
     const id = uuidv4();
+    const normalizedDescription = type === 'category' ? null : description?.trim() || null;
 
     runQuery(
-      'INSERT INTO meals (id, host_id, title, description) VALUES (?, ?, ?, ?)',
-      [id, req.session.hostId, title.trim(), description?.trim() || null]
+      'INSERT INTO meals (id, host_id, title, description, type) VALUES (?, ?, ?, ?, ?)',
+      [id, req.session.hostId, normalizedTitle, normalizedDescription, type]
     );
+
+    if (type === 'category') {
+      runQuery(
+        'UPDATE hosts SET takeout_onboarding_dismissed = 1 WHERE id = ?',
+        [req.session.hostId]
+      );
+    }
 
     res.status(201).json({
       id,
-      title: title.trim(),
-      description: description?.trim() || null,
-      type: 'meal',
+      title: normalizedTitle,
+      description: normalizedDescription,
+      type,
       pickCount: 0,
     });
   } catch (error) {
@@ -98,7 +154,7 @@ router.patch('/:id', (req, res) => {
 
     // Verify ownership
     const meal = getOne<Meal>(
-      'SELECT id FROM meals WHERE id = ? AND host_id = ?',
+      'SELECT id, type FROM meals WHERE id = ? AND host_id = ?',
       [id, req.session.hostId]
     );
 
@@ -116,11 +172,28 @@ router.patch('/:id', (req, res) => {
         res.status(400).json({ error: 'Title cannot be empty' });
         return;
       }
+      const duplicate = getOne<Meal>(
+        `SELECT id FROM meals
+         WHERE host_id = ? AND type = ? AND archived = 0
+           AND LOWER(title) = LOWER(?) AND id <> ?`,
+        [req.session.hostId, meal.type, title.trim(), id]
+      );
+      if (duplicate) {
+        res.status(409).json({
+          error: `A ${meal.type === 'category' ? 'food category' : 'meal'} with this name already exists`,
+          existingId: duplicate.id,
+        });
+        return;
+      }
       updates.push('title = ?');
       params.push(title.trim());
     }
 
     if (description !== undefined) {
+      if (meal.type === 'category') {
+        res.status(400).json({ error: 'Food categories do not support descriptions' });
+        return;
+      }
       updates.push('description = ?');
       params.push(description?.trim() || null);
     }
@@ -181,12 +254,26 @@ router.post('/:id/restore', (req, res) => {
 
     // Verify ownership
     const meal = getOne<Meal>(
-      'SELECT id FROM meals WHERE id = ? AND host_id = ?',
+      'SELECT id, title, type FROM meals WHERE id = ? AND host_id = ?',
       [id, req.session.hostId]
     );
 
     if (!meal) {
       res.status(404).json({ error: 'Meal not found' });
+      return;
+    }
+
+    const duplicate = getOne<Meal>(
+      `SELECT id FROM meals
+       WHERE host_id = ? AND type = ? AND archived = 0
+         AND LOWER(title) = LOWER(?) AND id <> ?`,
+      [req.session.hostId, meal.type, meal.title, id]
+    );
+    if (duplicate) {
+      res.status(409).json({
+        error: `An active ${meal.type === 'category' ? 'food category' : 'meal'} with this name already exists`,
+        existingId: duplicate.id,
+      });
       return;
     }
 

--- a/server/src/routes/quick-session.test.ts
+++ b/server/src/routes/quick-session.test.ts
@@ -4,6 +4,7 @@ describe('Quick Session API', () => {
   it('should validate quick session request structure', () => {
     const validRequest = {
       creatorName: 'Test User',
+      mode: 'takeout',
       meals: [
         { title: 'Pizza', description: 'Cheese pizza' },
         { title: 'Burgers', description: 'Beef burgers' },
@@ -13,6 +14,7 @@ describe('Quick Session API', () => {
 
     expect(validRequest).toHaveProperty('creatorName');
     expect(validRequest).toHaveProperty('meals');
+    expect(validRequest.mode).toBe('takeout');
     expect(validRequest.creatorName).toBeTruthy();
     expect(validRequest.meals.length).toBeGreaterThan(0);
   });
@@ -22,7 +24,8 @@ describe('Quick Session API', () => {
       session: {
         id: 'session-123',
         inviteCode: 'ABC123',
-        status: 'open'
+        status: 'open',
+        mode: 'takeout'
       },
       participantId: 'participant-123',
       creatorToken: 'token-123',
@@ -34,17 +37,20 @@ describe('Quick Session API', () => {
     expect(mockResponse).toHaveProperty('creatorToken');
     expect(mockResponse).toHaveProperty('mealIds');
     expect(mockResponse.session.status).toBe('open');
+    expect(mockResponse.session.mode).toBe('takeout');
     expect(mockResponse.session.inviteCode).toHaveLength(6);
   });
 
   it('should validate temporary meal structure', () => {
     const temporaryMeal = {
       temporary: 1,
-      creator_token: 'token-123'
+      creator_token: 'token-123',
+      type: 'category'
     };
 
     expect(temporaryMeal.temporary).toBe(1);
     expect(temporaryMeal.creator_token).toBeTruthy();
+    expect(temporaryMeal.type).toBe('category');
   });
 
   it('should validate error response for missing creator name', () => {

--- a/server/src/routes/quick-session.ts
+++ b/server/src/routes/quick-session.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
 import { runQuery } from '../db/schema.js';
 import { QuickSessionRequest } from '../types.js';
+import { hasDuplicateOptionTitles, isSessionMode, mealTypeForMode } from '../services/food-options.js';
 
 const router = Router();
 
@@ -19,10 +20,32 @@ function generateInviteCode(): string {
 // POST /api/quick-session - Create a quick session without authentication
 router.post('/', async (req: Request, res: Response) => {
   try {
-    const { creatorName, meals } = req.body as QuickSessionRequest;
+    const { creatorName, meals, mode = 'home' } = req.body as QuickSessionRequest;
 
     if (!creatorName || !meals || meals.length === 0) {
       res.status(400).json({ error: 'Creator name and at least one meal required' });
+      return;
+    }
+
+    if (!isSessionMode(mode)) {
+      res.status(400).json({ error: 'Mode must be home or takeout' });
+      return;
+    }
+
+    const normalizedMeals = meals
+      .map((meal) => ({
+        title: meal.title?.trim(),
+        description: meal.description?.trim(),
+      }))
+      .filter((meal) => meal.title);
+
+    if (normalizedMeals.length === 0) {
+      res.status(400).json({ error: 'At least one option is required' });
+      return;
+    }
+
+    if (hasDuplicateOptionTitles(normalizedMeals.map((meal) => meal.title))) {
+      res.status(400).json({ error: 'Option names must be unique within a session' });
       return;
     }
 
@@ -39,21 +62,23 @@ router.post('/', async (req: Request, res: Response) => {
     const inviteCode = generateInviteCode();
 
     runQuery(
-      `INSERT INTO sessions (id, host_id, invite_code, status, created_at)
-       VALUES (?, ?, ?, 'open', datetime('now'))`,
-      [sessionId, hostId, inviteCode]
+      `INSERT INTO sessions (id, host_id, invite_code, status, mode, created_at)
+       VALUES (?, ?, ?, 'open', ?, datetime('now'))`,
+      [sessionId, hostId, inviteCode, mode]
     );
 
     // Create temporary meals and add to session
-    const sessionMeals: Array<{ id: string; title: string; description: string | null; sessionMealId: string }> = [];
-    for (let i = 0; i < meals.length; i++) {
+    const optionType = mealTypeForMode(mode);
+    const sessionMeals: Array<{ id: string; title: string; description: string | null; type: string; sessionMealId: string }> = [];
+    for (let i = 0; i < normalizedMeals.length; i++) {
       const mealId = uuidv4();
-      const meal = meals[i];
+      const meal = normalizedMeals[i];
+      const description = mode === 'home' ? meal.description || null : null;
 
       runQuery(
         `INSERT INTO meals (id, host_id, title, description, type, temporary, creator_token, created_at)
-         VALUES (?, ?, ?, ?, 'meal', 1, ?, datetime('now'))`,
-        [mealId, hostId, meal.title, meal.description || null, creatorToken]
+         VALUES (?, ?, ?, ?, ?, 1, ?, datetime('now'))`,
+        [mealId, hostId, meal.title, description, optionType, creatorToken]
       );
 
       // Add to session_meals
@@ -67,7 +92,8 @@ router.post('/', async (req: Request, res: Response) => {
       sessionMeals.push({
         id: mealId,
         title: meal.title,
-        description: meal.description || null,
+        description,
+        type: optionType,
         sessionMealId
       });
     }
@@ -84,7 +110,8 @@ router.post('/', async (req: Request, res: Response) => {
       session: {
         id: sessionId,
         inviteCode,
-        status: 'open'
+        status: 'open',
+        mode,
       },
       participantId,
       creatorToken: isAuthenticated ? null : creatorToken,

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -4,6 +4,7 @@ import { runQuery, getOne, getAll } from '../db/schema';
 import { Session, Meal, Participant, CreateSessionRequest } from '../types';
 import { requireAuth } from '../middleware/auth';
 import { generateInviteCode, calculateResults } from '../services/matching';
+import { isSessionMode, mealTypeForMode } from '../services/food-options';
 
 const router = Router();
 
@@ -28,6 +29,7 @@ router.get('/', (req, res) => {
       id: session.id,
       inviteCode: session.invite_code,
       status: session.status,
+      mode: session.mode,
       selectedMealId: session.selected_meal_id,
       mealCount: session.meal_count,
       participantCount: session.participant_count,
@@ -43,21 +45,35 @@ router.get('/', (req, res) => {
 // POST /api/sessions - Create session with meal IDs
 router.post('/', (req, res) => {
   try {
-    const { mealIds } = req.body as CreateSessionRequest;
+    const { mealIds, mode = 'home' } = req.body as CreateSessionRequest;
 
     if (!mealIds || mealIds.length === 0) {
-      res.status(400).json({ error: 'At least one meal is required' });
+      res.status(400).json({ error: 'At least one option is required' });
       return;
     }
 
+    if (new Set(mealIds).size !== mealIds.length) {
+      res.status(400).json({ error: 'Option IDs must be unique' });
+      return;
+    }
+
+    if (!isSessionMode(mode)) {
+      res.status(400).json({ error: 'Mode must be home or takeout' });
+      return;
+    }
+
+    const expectedType = mealTypeForMode(mode);
+
     // Verify all meals belong to this host and are not archived
     const meals = getAll<Meal>(
-      `SELECT id FROM meals WHERE id IN (${mealIds.map(() => '?').join(',')}) AND host_id = ? AND archived = 0`,
-      [...mealIds, req.session.hostId]
+      `SELECT id FROM meals
+       WHERE id IN (${mealIds.map(() => '?').join(',')})
+         AND host_id = ? AND archived = 0 AND type = ?`,
+      [...mealIds, req.session.hostId, expectedType]
     );
 
     if (meals.length !== mealIds.length) {
-      res.status(400).json({ error: 'Some meals are invalid or not accessible' });
+      res.status(400).json({ error: 'Some options are invalid, inaccessible, or do not match the session mode' });
       return;
     }
 
@@ -76,8 +92,8 @@ router.post('/', (req, res) => {
     // Create session
     const sessionId = uuidv4();
     runQuery(
-      'INSERT INTO sessions (id, host_id, invite_code) VALUES (?, ?, ?)',
-      [sessionId, req.session.hostId, inviteCode]
+      'INSERT INTO sessions (id, host_id, invite_code, mode) VALUES (?, ?, ?, ?)',
+      [sessionId, req.session.hostId, inviteCode, mode]
     );
 
     // Create session_meals entries with randomized order
@@ -93,6 +109,7 @@ router.post('/', (req, res) => {
       id: sessionId,
       inviteCode,
       status: 'open',
+      mode,
       mealCount: mealIds.length,
     });
   } catch (error) {
@@ -145,6 +162,7 @@ router.get('/:id', (req, res) => {
       id: session.id,
       inviteCode: session.invite_code,
       status: session.status,
+      mode: session.mode,
       selectedMealId: session.selected_meal_id,
       createdAt: session.created_at,
       closedAt: session.closed_at,
@@ -152,6 +170,7 @@ router.get('/:id', (req, res) => {
         id: m.id,
         title: m.title,
         description: m.description,
+        type: m.type,
       })),
       participants: participants.map(p => ({
         id: p.id,

--- a/server/src/routes/swipes.ts
+++ b/server/src/routes/swipes.ts
@@ -35,6 +35,7 @@ router.get('/join/:inviteCode', (req, res) => {
     res.json({
       id: session.id,
       status: session.status,
+      mode: session.mode,
       participantCount: participantCount?.count || 0,
     });
   } catch (error) {
@@ -78,7 +79,7 @@ router.post('/join/:inviteCode', (req, res) => {
 
     // Get meals for this session (randomized order for this participant)
     const meals = getAll<Meal & { session_meal_id: string }>(
-      `SELECT m.id, m.title, m.description, sm.id as session_meal_id
+      `SELECT m.id, m.title, m.description, m.type, sm.id as session_meal_id
        FROM meals m
        JOIN session_meals sm ON m.id = sm.meal_id
        WHERE sm.session_id = ?`,
@@ -91,10 +92,12 @@ router.post('/join/:inviteCode', (req, res) => {
     res.status(201).json({
       participantId,
       sessionId: session.id,
+      mode: session.mode,
       meals: shuffledMeals.map(m => ({
         id: m.id,
         title: m.title,
         description: m.description,
+        type: m.type,
         sessionMealId: m.session_meal_id,
       })),
     });
@@ -195,6 +198,7 @@ router.get('/results/:sessionId', (req, res) => {
     if (session.status !== 'closed') {
       res.json({
         status: 'waiting',
+        mode: session.mode,
         message: 'Session is still open. Results will be available after the host closes it.',
       });
       return;
@@ -206,18 +210,20 @@ router.get('/results/:sessionId', (req, res) => {
     // Get selected meal info if any
     let selectedMeal = null;
     if (session.selected_meal_id) {
-      const meal = getOne<Meal>('SELECT id, title, description FROM meals WHERE id = ?', [session.selected_meal_id]);
+      const meal = getOne<Meal>('SELECT id, title, description, type FROM meals WHERE id = ?', [session.selected_meal_id]);
       if (meal) {
         selectedMeal = {
           id: meal.id,
           title: meal.title,
           description: meal.description,
+          type: meal.type,
         };
       }
     }
 
     res.json({
       status: 'closed',
+      mode: session.mode,
       results,
       selectedMeal,
       isHost: requestorIsHost,
@@ -292,7 +298,7 @@ router.get('/session-status/:sessionId', (req, res) => {
   try {
     const { sessionId } = req.params;
 
-    const session = getOne<Session>('SELECT status, selected_meal_id FROM sessions WHERE id = ?', [sessionId]);
+    const session = getOne<Session>('SELECT status, mode, selected_meal_id FROM sessions WHERE id = ?', [sessionId]);
 
     if (!session) {
       res.status(404).json({ error: 'Session not found' });
@@ -310,6 +316,7 @@ router.get('/session-status/:sessionId', (req, res) => {
 
     res.json({
       status: session.status,
+      mode: session.mode,
       selectedMealId: session.selected_meal_id,
       participants: participants.map(p => ({
         id: p.id,

--- a/server/src/services/food-options.test.ts
+++ b/server/src/services/food-options.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasDuplicateOptionTitles,
+  isSessionMode,
+  mealTypeForMode,
+} from './food-options';
+
+describe('food option domain rules', () => {
+  it('recognizes only supported session modes', () => {
+    expect(isSessionMode('home')).toBe(true);
+    expect(isSessionMode('takeout')).toBe(true);
+    expect(isSessionMode('mixed')).toBe(false);
+    expect(isSessionMode(undefined)).toBe(false);
+  });
+
+  it('maps each session mode to its allowed option type', () => {
+    expect(mealTypeForMode('home')).toBe('meal');
+    expect(mealTypeForMode('takeout')).toBe('category');
+  });
+
+  it('detects duplicate titles case-insensitively after trimming', () => {
+    expect(hasDuplicateOptionTitles(['Pizza', ' pizza '])).toBe(true);
+    expect(hasDuplicateOptionTitles(['Pizza', 'Sushi'])).toBe(false);
+  });
+});

--- a/server/src/services/food-options.ts
+++ b/server/src/services/food-options.ts
@@ -1,0 +1,14 @@
+import { MealType, SessionMode } from '../types';
+
+export function isSessionMode(value: unknown): value is SessionMode {
+  return value === 'home' || value === 'takeout';
+}
+
+export function mealTypeForMode(mode: SessionMode): MealType {
+  return mode === 'home' ? 'meal' : 'category';
+}
+
+export function hasDuplicateOptionTitles(titles: string[]): boolean {
+  const normalized = titles.map((title) => title.trim().toLowerCase());
+  return new Set(normalized).size !== normalized.length;
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,8 +1,13 @@
+// Shared domain types
+export type SessionMode = 'home' | 'takeout';
+export type MealType = 'meal' | 'category' | 'restaurant';
+
 // Database entity types
 export interface Host {
   id: string;
   email: string;
   password_hash: string;
+  takeout_onboarding_dismissed: number;
   created_at: string;
 }
 
@@ -11,7 +16,7 @@ export interface Meal {
   host_id: string;
   title: string;
   description: string | null;
-  type: 'meal' | 'restaurant';
+  type: MealType;
   archived: number; // SQLite boolean (0 or 1)
   pick_count: number;
   temporary: number; // SQLite boolean (0 or 1)
@@ -24,6 +29,7 @@ export interface Session {
   host_id: string;
   invite_code: string;
   status: 'open' | 'closed';
+  mode: SessionMode;
   selected_meal_id: string | null;
   created_at: string;
   closed_at: string | null;
@@ -83,10 +89,12 @@ export interface SessionWithDetails extends Session {
 export interface CreateMealRequest {
   title: string;
   description?: string;
+  type?: MealType;
 }
 
 export interface CreateSessionRequest {
   mealIds: string[];
+  mode?: SessionMode;
 }
 
 export interface JoinSessionRequest {
@@ -108,7 +116,12 @@ export interface LoginRequest {
   password: string;
 }
 
+export interface UpdateHostPreferencesRequest {
+  takeoutOnboardingDismissed: boolean;
+}
+
 export interface QuickSessionRequest {
   creatorName: string;
   meals: { title: string; description?: string }[];
+  mode?: SessionMode;
 }


### PR DESCRIPTION
## Summary
- Add separate home-meal and takeout-category libraries with mode-safe sessions.
- Add takeout suggestions and a one-time, persisted onboarding flow for empty takeout libraries.
- Keep anonymous quick sessions takeout-first while preserving identical voting and results behavior.
- Isolate Playwright data so end-to-end runs do not alter the local persistent database.

## Verification
- npm test (109 tests)
- npm run lint
- npm --prefix client run build
- npm --prefix server run build
- npx playwright test e2e/food-modes.spec.ts