### PR TITLE
Enable whole-card bulk selection

### DIFF
--- a/Ideas.md
+++ b/Ideas.md
@@ -11,7 +11,6 @@ No ungroomed ideas right now.
 ## Now
 
 - **Selection recency** — Count only the host's explicit final choice. Make selection idempotent, expose the last-selected time, and show `Never selected` or the date in the meal library. Whether to add recency sorting remains open.
-- **Whole-card bulk selection** — In bulk-edit mode, clicking anywhere on a meal card should toggle its checkbox without double toggles or accessibility regressions.
 
 ## Next
 

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -169,6 +169,27 @@ describe('Dashboard - Edit Mode and Delete', () => {
     expect(screen.getByText('Delete Selected (2)')).toBeDefined();
   });
 
+  it('should toggle a meal once when its card or checkbox is clicked in edit mode', async () => {
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText('Edit'));
+    fireEvent.click(screen.getByText('Pizza'));
+
+    expect(screen.getByText('Delete Selected (1)')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Pizza for deletion' }));
+
+    expect(screen.queryByText('Delete Selected (1)')).toBeNull();
+  });
+
   it('should show confirmation modal for single delete', async () => {
     render(
       <BrowserRouter>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -474,11 +474,13 @@ export function Dashboard() {
                 {activeMeals.map((meal) => {
                   const isDeleting = deletingMealIds.includes(meal.id);
                   const isSingleDelete = deletingMealIds.length === 1 && isDeleting;
+                  const isSelectedForDeletion = selectedForDeletion.includes(meal.id);
 
                   return (
                     <motion.div
                       key={meal.id}
                       layout
+                      onClick={editMode ? () => toggleMealForDeletion(meal.id) : undefined}
                       initial={{ opacity: 1 }}
                       exit={
                         isSingleDelete
@@ -493,15 +495,17 @@ export function Dashboard() {
                             }
                       }
                       className={`card transition-colors duration-150 ${
-                        isDeleting ? 'bg-red-50' : ''
-                      }`}
+                        editMode ? 'cursor-pointer' : ''
+                      } ${isDeleting ? 'bg-red-50' : ''}`}
                     >
                       <div className="flex justify-between items-start gap-3">
                         {editMode && (
                           <input
                             type="checkbox"
-                            checked={selectedForDeletion.includes(meal.id)}
+                            checked={isSelectedForDeletion}
+                            onClick={(event) => event.stopPropagation()}
                             onChange={() => toggleMealForDeletion(meal.id)}
+                            aria-label={`Select ${meal.title} for deletion`}
                             className="w-5 h-5 mt-1 text-primary-600 cursor-pointer"
                           />
                         )}


### PR DESCRIPTION
## Problem and outcome

Bulk editing required clicking the small checkbox on each saved option. Cards can now be clicked anywhere in edit mode to toggle that selection.

## Implemented first slice

- Toggle an option when its card is clicked in bulk-edit mode.
- Stop checkbox click propagation so checkbox clicks toggle exactly once.
- Add accessible checkbox names.
- Add regression coverage for card selection and checkbox deselection.

## Decisions and exclusions

The interaction is limited to bulk-edit mode. Normal card behavior and delete/edit controls are unchanged. No API or database changes were needed.

## Verification

- 
pm --prefix client test -- --run src/pages/Dashboard.test.tsx
- 
pm run lint
- 
pm --prefix client run build

## Deferred follow-ups

None.