### PR TITLE
Add selection recency to meal library

### DIFF
--- a/Ideas.md
+++ b/Ideas.md
@@ -10,7 +10,6 @@ No ungroomed ideas right now.
 
 ## Now
 
-- **Whole-card bulk selection** — In bulk-edit mode, clicking anywhere on a meal card should toggle its checkbox without double toggles or accessibility regressions.
 
 ## Next
 

--- a/Ideas.md
+++ b/Ideas.md
@@ -10,7 +10,6 @@ No ungroomed ideas right now.
 
 ## Now
 
-- **Selection recency** — Count only the host's explicit final choice. Make selection idempotent, expose the last-selected time, and show `Never selected` or the date in the meal library. Whether to add recency sorting remains open.
 - **Whole-card bulk selection** — In bulk-edit mode, clicking anywhere on a meal card should toggle its checkbox without double toggles or accessibility regressions.
 
 ## Next

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -89,6 +89,7 @@ export interface Meal {
   type: MealType;
   pickCount: number;
   createdAt?: string;
+  lastSelectedAt?: string | null;
   archived?: boolean;
 }
 

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -36,6 +36,7 @@ const mockMeals: Meal[] = [
     archived: false,
     pickCount: 5,
     createdAt: '2024-01-01',
+    lastSelectedAt: '2024-01-04 12:00:00',
   },
   {
     id: '2',
@@ -45,6 +46,7 @@ const mockMeals: Meal[] = [
     archived: false,
     pickCount: 3,
     createdAt: '2024-01-02',
+    lastSelectedAt: '2024-01-05 12:00:00',
   },
   {
     id: '3',
@@ -54,6 +56,7 @@ const mockMeals: Meal[] = [
     archived: false,
     pickCount: 0,
     createdAt: '2024-01-03',
+    lastSelectedAt: null,
   },
 ];
 
@@ -88,6 +91,17 @@ describe('Dashboard - Edit Mode and Delete', () => {
     await waitFor(() => {
       expect(screen.queryByText('Edit')).toBeNull();
     });
+  });
+
+  it('shows each meal\'s last selection date or that it has never been selected', async () => {
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    expect(await screen.findByText(/Last selected Jan 4, 2024/)).toBeDefined();
+    expect(screen.getByText('Never selected')).toBeDefined();
   });
 
   it('should toggle edit mode when Edit button is clicked', async () => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -6,6 +6,18 @@ import { authApi, mealsApi, sessionsApi, Meal, Session, SessionMode } from '../a
 import ConfirmModal from '../components/ConfirmModal';
 import { TAKEOUT_CATEGORY_SUGGESTIONS } from '../constants/takeoutCategories';
 
+function formatLastSelectedAt(timestamp: string | null | undefined): string {
+  if (!timestamp) return 'Never selected';
+
+  const date = new Date(`${timestamp.replace(' ', 'T')}Z`);
+  return `Last selected ${new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date)}`;
+}
+
 export function Dashboard() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
@@ -510,11 +522,12 @@ export function Dashboard() {
                           {meal.description && (
                             <p className="text-gray-600 text-sm mt-1">{meal.description}</p>
                           )}
-                          {meal.pickCount > 0 && (
-                            <p className="text-xs text-gray-400 mt-2">
-                              Selected {meal.pickCount} time{meal.pickCount !== 1 ? 's' : ''}
-                            </p>
-                          )}
+                          <p className="text-xs text-gray-400 mt-2">
+                            {meal.pickCount > 0 && (
+                              <>Selected {meal.pickCount} time{meal.pickCount !== 1 ? 's' : ''} · </>
+                            )}
+                            {formatLastSelectedAt(meal.lastSelectedAt)}
+                          </p>
                         </div>
                         {!editMode && (
                           <div className="flex gap-2">

--- a/e2e/authenticated-host.spec.ts
+++ b/e2e/authenticated-host.spec.ts
@@ -99,6 +99,31 @@ test.describe('Authenticated Host Flow', () => {
 
     // And: Can see vote percentages
     await expect(page.locator('text=/%/').first()).toBeVisible();
+
+    // Selecting the final option is safe to retry: it must not increment its count twice.
+    await page.getByRole('button', { name: 'Select' }).first().click();
+    await expect(page.getByText(/^Selected:/)).toBeVisible();
+
+    const sessionId = new URL(page.url()).pathname.split('/').pop();
+    const selectedMealId = await page.evaluate(async (id) => {
+      const response = await fetch(`/api/sessions/${id}`);
+      const session = await response.json();
+      return session.selectedMealId as string;
+    }, sessionId);
+
+    const retryResponse = await page.evaluate(async ({ id, mealId }) => {
+      const response = await fetch(`/api/sessions/${id}/select`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mealId }),
+      });
+      return { ok: response.ok, body: await response.json() };
+    }, { id: sessionId, mealId: selectedMealId });
+
+    expect(retryResponse.ok).toBe(true);
+    await page.goto('/dashboard');
+    await expect(page.getByText('Selected 1 time')).toBeVisible();
+    await expect(page.getByText(/Last selected/)).toBeVisible();
   });
 
   test('host can quick add meals while creating session', async ({ page }) => {

--- a/server/src/routes/meals.ts
+++ b/server/src/routes/meals.ts
@@ -31,7 +31,8 @@ router.get('/', (req, res) => {
       ? [req.session.hostId, requestedType]
       : [req.session.hostId];
     const meals = getAll<Meal>(
-      `SELECT id, title, description, type, archived, pick_count, created_at
+      `SELECT id, title, description, type, archived, pick_count, created_at,
+        (SELECT MAX(selected_at) FROM session_history WHERE selected_meal_id = meals.id) AS last_selected_at
        FROM meals
        WHERE host_id = ? AND archived = 0${typeFilter}
        ORDER BY created_at DESC`,
@@ -45,6 +46,7 @@ router.get('/', (req, res) => {
       type: meal.type,
       pickCount: meal.pick_count,
       createdAt: meal.created_at,
+      lastSelectedAt: meal.last_selected_at ?? null,
     })));
   } catch (error) {
     console.error('Get meals error:', error);
@@ -66,7 +68,8 @@ router.get('/all', (req, res) => {
       ? [req.session.hostId, requestedType]
       : [req.session.hostId];
     const meals = getAll<Meal>(
-      `SELECT id, title, description, type, archived, pick_count, created_at
+      `SELECT id, title, description, type, archived, pick_count, created_at,
+        (SELECT MAX(selected_at) FROM session_history WHERE selected_meal_id = meals.id) AS last_selected_at
        FROM meals
        WHERE host_id = ?${typeFilter}
        ORDER BY created_at DESC`,
@@ -81,6 +84,7 @@ router.get('/all', (req, res) => {
       archived: meal.archived === 1,
       pickCount: meal.pick_count,
       createdAt: meal.created_at,
+      lastSelectedAt: meal.last_selected_at ?? null,
     })));
   } catch (error) {
     console.error('Get all meals error:', error);

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -278,6 +278,16 @@ router.post('/:id/select', (req, res) => {
       return;
     }
 
+    if (session.selected_meal_id) {
+      if (session.selected_meal_id === mealId) {
+        res.json({ message: 'Meal selected successfully' });
+        return;
+      }
+
+      res.status(409).json({ error: 'A final meal has already been selected for this session' });
+      return;
+    }
+
     // Verify meal is part of this session
     const sessionMeal = getOne(
       'SELECT id FROM session_meals WHERE session_id = ? AND meal_id = ?',

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -22,6 +22,7 @@ export interface Meal {
   temporary: number; // SQLite boolean (0 or 1)
   creator_token: string | null;
   created_at: string;
+  last_selected_at?: string | null;
 }
 
 export interface Session {


### PR DESCRIPTION
## Problem and outcome
Final-selection retries could increment an option's count more than once and overwrite its history timestamp. The meal library did not show when an option was last selected.

## Implemented first slice
- Make final selection immutable; repeat requests for the selected option succeed without writes.
- Return each meal or category's latest selection timestamp and display a UTC-stable date or `Never selected` in the library.

## Decisions and exclusions
- A different follow-up selection returns a conflict; changing an existing final choice is not supported.
- Recency sorting is deliberately deferred.

## Verification
- `npm test -- --run` (110 passing tests)
- `npm --prefix client run build`
- `npm --prefix server run build`
- Focused Playwright flow added but not run: port 5173 was already occupied, and the configured runner cannot safely reuse it without losing database isolation.

## Deferred follow-ups
- Consider recency sorting separately.