### PR TITLE
Add private recipe foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ MealMatch is a collaborative meal-decision app. A group creates a session, votes
 
 - The public home page (`/`) creates an account-free quick session. It defaults to takeout categories, still supports home meals, auto-joins the creator, stores participant/session data in browser storage, and gives an anonymous creator a secret token that can close the session.
 - Authenticated hosts can register or log in, manage separate home-meal and takeout-category libraries, create sessions, monitor participants, close sessions, view voter details, and select the final option.
+- Authenticated hosts can keep private recipe instructions and ordered free-text amount/ingredient rows on home meals. They can fill the editable meal form through a validated full-recipe paste format, and recipe data stays out of session participant payloads.
 - A new authenticated takeout library starts with a one-time onboarding choice: select popular categories or add a custom category. The dismissal is stored on the host record, and creating any takeout category also dismisses it, so onboarding does not return when the library later becomes empty.
 - Other participants join through a six-character invite code. The meal pool is fixed when a session is created, but a participant can update submitted choices while the session remains open.
 - Votes are numeric across every layer: `0 = no`, `1 = yes`, and `2 = maybe`. Results treat yes and maybe as acceptable, treat only all-yes as unanimous, and rank tied acceptance percentages by fewer maybes.
@@ -82,6 +83,7 @@ Playwright starts its server with a per-run database under `test-results/` and d
 - Protect authenticated host routes with both authentication and resource ownership checks. Anonymous close operations must validate the creator token without returning or logging it.
 - Express session storage currently uses the package default memory store. Do not assume login sessions are durable across server restarts or multiple production instances.
 - Public result responses must not expose voter identities. Host voter detail is allowed only after server-side host verification; a query-string flag alone is not authorization.
+- Recipe instructions and ingredients are private host-library data. Reject them for takeout categories, preserve ingredient order and free-text amounts, and never add recipe fields to public join, swipe, session, or result payloads.
 - Browser recovery uses both `sessionStorage` for join/session context and `localStorage` for in-progress swipes. Preserve the storage contracts when changing join, share, swipe, edit, or result flows.
 - Declare React hooks before conditional returns and keep effect dependencies accurate. Add regression coverage for async navigation, polling, and storage behavior.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ MealMatch is a collaborative meal-decision app. A group creates a session, votes
 
 - The public home page (`/`) creates an account-free quick session. It defaults to takeout categories, still supports home meals, auto-joins the creator, stores participant/session data in browser storage, and gives an anonymous creator a secret token that can close the session.
 - Authenticated hosts can register or log in, manage separate home-meal and takeout-category libraries, create sessions, monitor participants, close sessions, view voter details, and select the final option.
-- Authenticated hosts can keep private recipe instructions and ordered free-text amount/ingredient rows on home meals. They can fill the editable meal form through a validated full-recipe paste format, and recipe data stays out of session participant payloads.
+- Authenticated hosts can keep private recipe instructions and ordered free-text amount/ingredient rows on home meals. They can fill the editable meal form through a validated full-recipe paste format and open a read-only recipe view from their library or session results; recipe data stays out of session participant payloads.
 - A new authenticated takeout library starts with a one-time onboarding choice: select popular categories or add a custom category. The dismissal is stored on the host record, and creating any takeout category also dismisses it, so onboarding does not return when the library later becomes empty.
 - Other participants join through a six-character invite code. The meal pool is fixed when a session is created, but a participant can update submitted choices while the session remains open.
 - Votes are numeric across every layer: `0 = no`, `1 = yes`, and `2 = maybe`. Results treat yes and maybe as acceptable, treat only all-yes as unanimous, and rank tied acceptance percentages by fewer maybes.
@@ -83,7 +83,7 @@ Playwright starts its server with a per-run database under `test-results/` and d
 - Protect authenticated host routes with both authentication and resource ownership checks. Anonymous close operations must validate the creator token without returning or logging it.
 - Express session storage currently uses the package default memory store. Do not assume login sessions are durable across server restarts or multiple production instances.
 - Public result responses must not expose voter identities. Host voter detail is allowed only after server-side host verification; a query-string flag alone is not authorization.
-- Recipe instructions and ingredients are private host-library data. Reject them for takeout categories, preserve ingredient order and free-text amounts, and never add recipe fields to public join, swipe, session, or result payloads.
+- Recipe instructions and ingredients are private host-library data. Reject them for takeout categories, preserve ingredient order and free-text amounts, never add recipe fields to public join, swipe, session, or result payloads, and load host recipe views through an authenticated ownership-checked meal route.
 - Browser recovery uses both `sessionStorage` for join/session context and `localStorage` for in-progress swipes. Preserve the storage contracts when changing join, share, swipe, edit, or result flows.
 - Declare React hooks before conditional returns and keep effect dependencies accurate. Add regression coverage for async navigation, polling, and storage behavior.
 

--- a/Ideas.md
+++ b/Ideas.md
@@ -10,13 +10,12 @@ No ungroomed ideas right now.
 
 ## Now
 
+- **Library export and import** — Transfer active home meals and takeout categories with versioned JSON, validation, preview, and duplicate reporting. Do not transfer IDs, ownership, tokens, counts, or history.
 
 ## Next
 
-- **Library export and import** — Transfer active home meals and takeout categories with versioned JSON, validation, preview, and duplicate reporting. Do not transfer IDs, ownership, tokens, counts, or history.
-- **Recipe and ingredient foundation** — Add recipe instructions and structured ingredient rows to home meals. Recipe visibility to session participants remains open.
+- **Weekly planning and shopping lists** — Choose three to five home meals in a separate planning flow and generate a checkable list grouped by meal, preserving ingredients as entered without unit consolidation.
 
 ## Later
 
-- **Weekly planning and shopping lists** — Choose three to five home meals in a separate planning flow and generate a checkable list grouped by meal, preserving ingredients as entered without unit consolidation.
 - **Pictures** — Support one image per home meal after choosing durable storage and deciding whether images appear on public session screens. Restaurant-specific images wait for a real restaurant model.

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -63,4 +63,50 @@ describe('API Client - Session Closed Handling', () => {
       sessionClosed: false,
     });
   });
+
+  it('sends recipe instructions and two-field ingredient rows for home meals', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'meal-123',
+        title: 'Garlic soup',
+        description: null,
+        type: 'meal',
+        pickCount: 0,
+        instructions: 'Simmer.',
+        ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+      }),
+    });
+
+    await mealsApi.create('Garlic soup', undefined, 'meal', {
+      instructions: 'Simmer.',
+      ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+    });
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
+      title: 'Garlic soup',
+      type: 'meal',
+      instructions: 'Simmer.',
+      ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+    });
+  });
+
+  it('sends full recipe text to the authenticated parser', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        title: 'Garlic Soup',
+        description: null,
+        instructions: 'Simmer.',
+        ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+      }),
+    });
+
+    await mealsApi.parseRecipe('Title: Garlic Soup');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/meals/parse-recipe', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ text: 'Title: Garlic Soup' }),
+    }));
+  });
 });

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -109,4 +109,23 @@ describe('API Client - Session Closed Handling', () => {
       body: JSON.stringify({ text: 'Title: Garlic Soup' }),
     }));
   });
+
+  it('loads one host-owned meal for the read-only recipe viewer', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'meal-123',
+        title: 'Garlic Soup',
+        description: null,
+        type: 'meal',
+        pickCount: 1,
+        instructions: 'Simmer.',
+        ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+      }),
+    });
+
+    await mealsApi.get('meal-123');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/meals/meal-123', expect.any(Object));
+  });
 });

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -125,6 +125,8 @@ export const mealsApi = {
   listAll: (type?: MealType) =>
     request<Meal[]>(`/meals/all${type ? `?type=${type}` : ''}`),
 
+  get: (id: string) => request<Meal>(`/meals/${id}`),
+
   create: (
     title: string,
     description?: string,
@@ -159,6 +161,7 @@ export interface Session {
   status: 'open' | 'closed';
   mode: SessionMode;
   selectedMealId: string | null;
+  selectedMeal: { id: string; title: string; type: MealType } | null;
   mealCount: number;
   participantCount: number;
   createdAt: string;

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -82,10 +82,29 @@ export const authApi = {
 export type SessionMode = 'home' | 'takeout';
 export type MealType = 'meal' | 'category' | 'restaurant';
 
+export interface RecipeIngredient {
+  amount: string;
+  ingredient: string;
+}
+
+export interface RecipeInput {
+  instructions?: string | null;
+  ingredients?: RecipeIngredient[];
+}
+
+export interface ParsedRecipe {
+  title: string;
+  description: string | null;
+  instructions: string | null;
+  ingredients: RecipeIngredient[];
+}
+
 export interface Meal {
   id: string;
   title: string;
   description: string | null;
+  instructions?: string | null;
+  ingredients?: RecipeIngredient[];
   type: MealType;
   pickCount: number;
   createdAt?: string;
@@ -94,19 +113,33 @@ export interface Meal {
 }
 
 export const mealsApi = {
+  parseRecipe: (text: string) =>
+    request<ParsedRecipe>('/meals/parse-recipe', {
+      method: 'POST',
+      body: JSON.stringify({ text }),
+    }),
+
   list: (type?: MealType) =>
     request<Meal[]>(`/meals${type ? `?type=${type}` : ''}`),
 
   listAll: (type?: MealType) =>
     request<Meal[]>(`/meals/all${type ? `?type=${type}` : ''}`),
 
-  create: (title: string, description?: string, type: MealType = 'meal') =>
+  create: (
+    title: string,
+    description?: string,
+    type: MealType = 'meal',
+    recipe?: RecipeInput
+  ) =>
     request<Meal>('/meals', {
       method: 'POST',
-      body: JSON.stringify({ title, description, type }),
+      body: JSON.stringify({ title, description, type, ...recipe }),
     }),
 
-  update: (id: string, data: { title?: string; description?: string }) =>
+  update: (
+    id: string,
+    data: { title?: string; description?: string; instructions?: string | null; ingredients?: RecipeIngredient[] }
+  ) =>
     request<Meal>(`/meals/${id}`, {
       method: 'PATCH',
       body: JSON.stringify(data),

--- a/client/src/components/RecipeFields.tsx
+++ b/client/src/components/RecipeFields.tsx
@@ -1,0 +1,124 @@
+import { RecipeIngredient } from '../api/client';
+
+interface RecipeFieldsProps {
+  instructions: string;
+  ingredients: RecipeIngredient[];
+  onInstructionsChange: (value: string) => void;
+  onIngredientsChange: (value: RecipeIngredient[]) => void;
+}
+
+export default function RecipeFields({
+  instructions,
+  ingredients,
+  onInstructionsChange,
+  onIngredientsChange,
+}: RecipeFieldsProps) {
+  const updateIngredient = (
+    index: number,
+    field: keyof RecipeIngredient,
+    value: string
+  ) => {
+    onIngredientsChange(
+      ingredients.map((row, rowIndex) =>
+        rowIndex === index ? { ...row, [field]: value } : row
+      )
+    );
+  };
+
+  const moveIngredient = (index: number, offset: -1 | 1) => {
+    const destination = index + offset;
+    if (destination < 0 || destination >= ingredients.length) return;
+
+    const reordered = [...ingredients];
+    [reordered[index], reordered[destination]] = [reordered[destination], reordered[index]];
+    onIngredientsChange(reordered);
+  };
+
+  return (
+    <fieldset className="space-y-4 border-t border-gray-200 pt-4">
+      <legend className="font-semibold text-gray-900">Recipe (optional)</legend>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Instructions
+        </label>
+        <textarea
+          value={instructions}
+          onChange={(event) => onInstructionsChange(event.target.value)}
+          className="input"
+          rows={4}
+          placeholder="Describe how to make this meal"
+        />
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium text-gray-700">Ingredients</span>
+          <button
+            type="button"
+            onClick={() => onIngredientsChange([...ingredients, { amount: '', ingredient: '' }])}
+            className="text-sm font-medium text-primary-600 hover:text-primary-700"
+          >
+            Add ingredient
+          </button>
+        </div>
+
+        {ingredients.length === 0 ? (
+          <p className="text-sm text-gray-500">No ingredients added.</p>
+        ) : (
+          <div className="space-y-2">
+            {ingredients.map((row, index) => (
+              <div key={index} className="grid grid-cols-[minmax(0,0.35fr)_minmax(0,1fr)_auto] gap-2 items-center">
+                <input
+                  type="text"
+                  value={row.amount}
+                  onChange={(event) => updateIngredient(index, 'amount', event.target.value)}
+                  className="input"
+                  placeholder="Amount"
+                  aria-label={`Ingredient ${index + 1} amount`}
+                />
+                <input
+                  type="text"
+                  value={row.ingredient}
+                  onChange={(event) => updateIngredient(index, 'ingredient', event.target.value)}
+                  className="input"
+                  placeholder="Ingredient"
+                  aria-label={`Ingredient ${index + 1} name`}
+                  required
+                />
+                <div className="flex">
+                  <button
+                    type="button"
+                    onClick={() => moveIngredient(index, -1)}
+                    disabled={index === 0}
+                    className="p-1 text-gray-500 disabled:text-gray-300"
+                    aria-label={`Move ingredient ${index + 1} up`}
+                  >
+                    ↑
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => moveIngredient(index, 1)}
+                    disabled={index === ingredients.length - 1}
+                    className="p-1 text-gray-500 disabled:text-gray-300"
+                    aria-label={`Move ingredient ${index + 1} down`}
+                  >
+                    ↓
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onIngredientsChange(ingredients.filter((_, rowIndex) => rowIndex !== index))}
+                    className="p-1 text-red-500"
+                    aria-label={`Remove ingredient ${index + 1}`}
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </fieldset>
+  );
+}

--- a/client/src/components/RecipePasteImport.tsx
+++ b/client/src/components/RecipePasteImport.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { mealsApi, ParsedRecipe } from '../api/client';
+
+interface RecipePasteImportProps {
+  onParsed: (recipe: ParsedRecipe) => void;
+}
+
+const recipeTemplate = `Title: Garlic Soup
+Description: Creamy roasted garlic soup
+Ingredients:
+2 bulbs | garlic
+4oz | milk
+to taste | salt
+Instructions:
+Roast the garlic.
+Blend and simmer.`;
+
+export default function RecipePasteImport({ onParsed }: RecipePasteImportProps) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const [error, setError] = useState('');
+  const [parsing, setParsing] = useState(false);
+
+  const close = () => {
+    setOpen(false);
+    setText('');
+    setError('');
+  };
+
+  const handleParse = async () => {
+    if (!text.trim()) return;
+
+    setParsing(true);
+    setError('');
+    try {
+      const recipe = await mealsApi.parseRecipe(text);
+      onParsed(recipe);
+      close();
+    } catch (parseError) {
+      setError(parseError instanceof Error ? parseError.message : 'Failed to parse recipe');
+    } finally {
+      setParsing(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="w-full rounded-lg border border-dashed border-primary-300 bg-primary-50 px-4 py-3 text-sm font-medium text-primary-700 hover:bg-primary-100"
+      >
+        Paste a full recipe
+      </button>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-primary-200 bg-primary-50 p-4 space-y-3">
+      <div>
+        <h4 className="font-semibold text-gray-900">Paste a full recipe</h4>
+        <p className="text-sm text-gray-600 mt-1">
+          Ask an LLM to use this exact format. Each ingredient must use
+          {' '}<code>amount | ingredient</code>.
+        </p>
+      </div>
+
+      <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-white p-3 text-xs text-gray-600 border border-gray-200">
+        {recipeTemplate}
+      </pre>
+
+      <textarea
+        value={text}
+        onChange={(event) => setText(event.target.value)}
+        className="input font-mono text-sm"
+        rows={10}
+        placeholder={recipeTemplate}
+        aria-label="Recipe text to parse"
+        autoFocus
+      />
+
+      {error && <p className="text-sm text-red-600" role="alert">{error}</p>}
+
+      <div className="flex gap-3">
+        <button type="button" onClick={close} className="btn btn-secondary flex-1">
+          Cancel paste
+        </button>
+        <button
+          type="button"
+          onClick={handleParse}
+          disabled={!text.trim() || parsing}
+          className="btn btn-primary flex-1"
+        >
+          {parsing ? 'Parsing…' : 'Fill recipe form'}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/RecipeViewer.tsx
+++ b/client/src/components/RecipeViewer.tsx
@@ -1,0 +1,79 @@
+import { Meal } from '../api/client';
+
+interface RecipeViewerProps {
+  meal: Meal;
+  onClose: () => void;
+}
+
+export default function RecipeViewer({ meal, onClose }: RecipeViewerProps) {
+  const hasIngredients = (meal.ingredients?.length ?? 0) > 0;
+  const hasInstructions = Boolean(meal.instructions?.trim());
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <article
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="recipe-viewer-title"
+        className="card max-h-[90vh] w-full max-w-2xl overflow-y-auto"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium text-primary-600">Recipe</p>
+            <h2 id="recipe-viewer-title" className="text-2xl font-bold">
+              {meal.title}
+            </h2>
+            {meal.description && (
+              <p className="mt-1 text-gray-600">{meal.description}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close recipe"
+            className="rounded p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {!hasIngredients && !hasInstructions ? (
+          <p className="mt-6 rounded-lg bg-gray-50 p-4 text-gray-600">
+            No recipe details have been added yet.
+          </p>
+        ) : (
+          <div className="mt-6 space-y-8">
+            {hasIngredients && (
+              <section>
+                <h3 className="text-lg font-bold">Ingredients</h3>
+                <ul className="mt-3 divide-y divide-gray-200 rounded-lg border border-gray-200">
+                  {meal.ingredients?.map((row, index) => (
+                    <li key={`${row.amount}-${row.ingredient}-${index}`} className="flex gap-4 px-4 py-3">
+                      <span className="w-28 shrink-0 font-medium text-gray-700">{row.amount}</span>
+                      <span className="text-gray-900">{row.ingredient}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {hasInstructions && (
+              <section>
+                <h3 className="text-lg font-bold">Instructions</h3>
+                <p className="mt-3 whitespace-pre-wrap text-gray-800">{meal.instructions}</p>
+              </section>
+            )}
+          </div>
+        )}
+      </article>
+    </div>
+  );
+}

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Dashboard } from './Dashboard';
 import { authApi, mealsApi, sessionsApi, Meal } from '../api/client';
@@ -18,6 +18,7 @@ vi.mock('../api/client', () => ({
   mealsApi: {
     parseRecipe: vi.fn(),
     list: vi.fn(),
+    get: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -1220,6 +1221,51 @@ Blend and simmer.`;
       expect(screen.getByLabelText('Ingredient 1 amount')).toHaveValue('2 bulbs');
       expect(screen.getByLabelText('Ingredient 2 name')).toHaveValue('milk');
     });
+  });
+
+  it('opens a readable recipe by clicking its library name', async () => {
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Garlic soup' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Garlic soup' });
+    expect(within(dialog).getByText('2 bulbs')).toBeInTheDocument();
+    expect(within(dialog).getByText('garlic')).toBeInTheDocument();
+    expect(within(dialog).getByText('Simmer until tender.')).toBeInTheDocument();
+  });
+
+  it('opens the selected meal recipe from Recent Sessions', async () => {
+    vi.mocked(mealsApi.get).mockResolvedValue(recipeMeal);
+    vi.mocked(sessionsApi.list).mockResolvedValue([{
+      id: 'session-1',
+      inviteCode: 'ABC123',
+      status: 'closed',
+      mode: 'home',
+      selectedMealId: 'recipe-1',
+      selectedMeal: { id: 'recipe-1', title: 'Garlic soup', type: 'meal' },
+      mealCount: 1,
+      participantCount: 2,
+      createdAt: '2024-01-01',
+      closedAt: '2024-01-01',
+    }]);
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    const recentSessions = (await screen.findByText('Recent Sessions')).closest('section');
+    expect(recentSessions).not.toBeNull();
+    fireEvent.click(within(recentSessions!).getByRole('button', { name: 'Garlic soup' }));
+
+    await waitFor(() => expect(mealsApi.get).toHaveBeenCalledWith('recipe-1'));
+    expect(screen.getByRole('dialog', { name: 'Garlic soup' })).toBeInTheDocument();
   });
 
   it('does not show recipe fields for takeout categories', async () => {

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../api/client', () => ({
     updatePreferences: vi.fn(),
   },
   mealsApi: {
+    parseRecipe: vi.fn(),
     list: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
@@ -1071,5 +1072,179 @@ describe('Dashboard - Home and takeout modes', () => {
       expect(screen.getByText('Add Food Category')).toBeInTheDocument();
     });
     expect(screen.queryByText('Popular categories')).not.toBeInTheDocument();
+  });
+});
+
+describe('Dashboard - Private Recipes', () => {
+  const recipeMeal: Meal = {
+    id: 'recipe-1',
+    title: 'Garlic soup',
+    description: 'Creamy soup',
+    instructions: 'Simmer until tender.',
+    ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+    type: 'meal',
+    archived: false,
+    pickCount: 0,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mealsApi.list).mockImplementation(async (type) =>
+      type === 'meal' ? [recipeMeal] : []
+    );
+    vi.mocked(sessionsApi.list).mockResolvedValue([]);
+  });
+
+  it('edits instructions and ordered two-field ingredient rows', async () => {
+    vi.mocked(mealsApi.update).mockResolvedValue({
+      ...recipeMeal,
+      ingredients: [
+        { amount: '2 bulbs', ingredient: 'garlic' },
+        { amount: '4oz', ingredient: 'milk' },
+      ],
+    });
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('Garlic soup');
+    fireEvent.click(screen.getByTitle('Edit meal'));
+    expect(screen.getByDisplayValue('Simmer until tender.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ingredient 1 amount')).toHaveValue('2 bulbs');
+    expect(screen.getByLabelText('Ingredient 1 name')).toHaveValue('garlic');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add ingredient' }));
+    fireEvent.change(screen.getByLabelText('Ingredient 2 amount'), {
+      target: { value: '4oz' },
+    });
+    fireEvent.change(screen.getByLabelText('Ingredient 2 name'), {
+      target: { value: 'milk' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mealsApi.update).toHaveBeenCalledWith('recipe-1', {
+        title: 'Garlic soup',
+        description: 'Creamy soup',
+        instructions: 'Simmer until tender.',
+        ingredients: [
+          { amount: '2 bulbs', ingredient: 'garlic' },
+          { amount: '4oz', ingredient: 'milk' },
+        ],
+      });
+    });
+  });
+
+  it('creates a home meal with an optional private recipe', async () => {
+    vi.mocked(mealsApi.create).mockResolvedValue({ ...recipeMeal, id: 'recipe-2' });
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Add Meal' }));
+    fireEvent.change(screen.getByPlaceholderText('e.g., Tacos'), {
+      target: { value: 'Garlic soup' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Describe how to make this meal'), {
+      target: { value: 'Simmer until tender.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add ingredient' }));
+    fireEvent.change(screen.getByLabelText('Ingredient 1 amount'), {
+      target: { value: '2 bulbs' },
+    });
+    fireEvent.change(screen.getByLabelText('Ingredient 1 name'), {
+      target: { value: 'garlic' },
+    });
+    const addMealButtons = screen.getAllByRole('button', { name: 'Add Meal' });
+    fireEvent.click(addMealButtons[addMealButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mealsApi.create).toHaveBeenCalledWith(
+        'Garlic soup',
+        undefined,
+        'meal',
+        {
+          instructions: 'Simmer until tender.',
+          ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+        }
+      );
+    });
+  });
+
+  it('fills the editable meal form from backend-parsed recipe text', async () => {
+    vi.mocked(mealsApi.parseRecipe).mockResolvedValue({
+      title: 'Garlic Soup',
+      description: 'Creamy roasted garlic soup',
+      instructions: 'Roast the garlic.\nBlend and simmer.',
+      ingredients: [
+        { amount: '2 bulbs', ingredient: 'garlic' },
+        { amount: '4oz', ingredient: 'milk' },
+      ],
+    });
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Add Meal' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Paste a full recipe' }));
+    const recipeText = `Title: Garlic Soup
+Description: Creamy roasted garlic soup
+Ingredients:
+2 bulbs | garlic
+4oz | milk
+Instructions:
+Roast the garlic.
+Blend and simmer.`;
+    fireEvent.change(screen.getByLabelText('Recipe text to parse'), {
+      target: { value: recipeText },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Fill recipe form' }));
+
+    await waitFor(() => {
+      expect(mealsApi.parseRecipe).toHaveBeenCalledWith(recipeText);
+      expect(screen.getByDisplayValue('Garlic Soup')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Creamy roasted garlic soup')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Describe how to make this meal'))
+        .toHaveValue('Roast the garlic.\nBlend and simmer.');
+      expect(screen.getByLabelText('Ingredient 1 amount')).toHaveValue('2 bulbs');
+      expect(screen.getByLabelText('Ingredient 2 name')).toHaveValue('milk');
+    });
+  });
+
+  it('does not show recipe fields for takeout categories', async () => {
+    vi.mocked(mealsApi.list).mockImplementation(async (type) =>
+      type === 'category'
+        ? [{
+            ...recipeMeal,
+            id: 'category-1',
+            title: 'Italian',
+            type: 'category',
+            instructions: undefined,
+            ingredients: undefined,
+          }]
+        : []
+    );
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Takeout' }));
+    fireEvent.click(screen.getByTitle('Edit category'));
+    expect(screen.queryByText('Recipe (optional)')).not.toBeInTheDocument();
   });
 });

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import {
 import ConfirmModal from '../components/ConfirmModal';
 import RecipeFields from '../components/RecipeFields';
 import RecipePasteImport from '../components/RecipePasteImport';
+import RecipeViewer from '../components/RecipeViewer';
 import { TAKEOUT_CATEGORY_SUGGESTIONS } from '../constants/takeoutCategories';
 
 function formatLastSelectedAt(timestamp: string | null | undefined): string {
@@ -69,6 +70,8 @@ export function Dashboard() {
   const [editDescription, setEditDescription] = useState('');
   const [editInstructions, setEditInstructions] = useState('');
   const [editIngredients, setEditIngredients] = useState<RecipeIngredient[]>([]);
+  const [viewingRecipe, setViewingRecipe] = useState<Meal | null>(null);
+  const [loadingRecipeId, setLoadingRecipeId] = useState<string | null>(null);
 
   // Animation states
   const [deletingMealIds, setDeletingMealIds] = useState<string[]>([]);
@@ -206,6 +209,23 @@ export function Dashboard() {
     setEditInstructions(meal.instructions || '');
     setEditIngredients(meal.ingredients?.map((row) => ({ ...row })) || []);
     setShowEditMeal(true);
+  };
+
+  const openRecipe = async (mealId: string, loadedMeal?: Meal) => {
+    if (loadedMeal?.type === 'meal') {
+      setViewingRecipe(loadedMeal);
+      return;
+    }
+
+    setLoadingRecipeId(mealId);
+    try {
+      const meal = await mealsApi.get(mealId);
+      if (meal.type === 'meal') setViewingRecipe(meal);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load recipe');
+    } finally {
+      setLoadingRecipeId(null);
+    }
   };
 
   const handleUpdateMeal = async (e: React.FormEvent) => {
@@ -563,7 +583,17 @@ export function Dashboard() {
                           />
                         )}
                         <div className="flex-1">
-                          <h3 className="font-semibold text-lg">{meal.title}</h3>
+                          {meal.type === 'meal' && !editMode ? (
+                            <button
+                              type="button"
+                              onClick={() => openRecipe(meal.id, meal)}
+                              className="text-left text-lg font-semibold text-primary-700 hover:underline"
+                            >
+                              {meal.title}
+                            </button>
+                          ) : (
+                            <h3 className="font-semibold text-lg">{meal.title}</h3>
+                          )}
                           {meal.description && (
                             <p className="text-gray-600 text-sm mt-1">{meal.description}</p>
                           )}
@@ -674,6 +704,28 @@ export function Dashboard() {
                       <p className="text-sm text-gray-500 mt-1">
                         {session.mealCount} options · {session.participantCount} participants
                       </p>
+                      {session.selectedMeal && (
+                        <p className="mt-1 text-sm text-gray-600">
+                          Selected:{' '}
+                          {session.selectedMeal.type === 'meal' ? (
+                            <button
+                              type="button"
+                              disabled={loadingRecipeId === session.selectedMeal.id}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                openRecipe(session.selectedMeal!.id);
+                              }}
+                              className="font-medium text-primary-700 hover:underline disabled:text-gray-400"
+                            >
+                              {loadingRecipeId === session.selectedMeal.id
+                                ? 'Loading recipe...'
+                                : session.selectedMeal.title}
+                            </button>
+                          ) : (
+                            <span className="font-medium">{session.selectedMeal.title}</span>
+                          )}
+                        </p>
+                      )}
                     </div>
                     <svg
                       className="w-5 h-5 text-gray-400"
@@ -690,6 +742,10 @@ export function Dashboard() {
           )}
         </section>
       </main>
+
+      {viewingRecipe && (
+        <RecipeViewer meal={viewingRecipe} onClose={() => setViewingRecipe(null)} />
+      )}
 
       {/* Takeout onboarding modal */}
       {showTakeoutOnboarding && (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -2,8 +2,18 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../hooks/useAuth';
-import { authApi, mealsApi, sessionsApi, Meal, Session, SessionMode } from '../api/client';
+import {
+  authApi,
+  mealsApi,
+  sessionsApi,
+  Meal,
+  RecipeIngredient,
+  Session,
+  SessionMode,
+} from '../api/client';
 import ConfirmModal from '../components/ConfirmModal';
+import RecipeFields from '../components/RecipeFields';
+import RecipePasteImport from '../components/RecipePasteImport';
 import { TAKEOUT_CATEGORY_SUGGESTIONS } from '../constants/takeoutCategories';
 
 function formatLastSelectedAt(timestamp: string | null | undefined): string {
@@ -32,6 +42,8 @@ export function Dashboard() {
   const [showCreateSession, setShowCreateSession] = useState(false);
   const [newMealTitle, setNewMealTitle] = useState('');
   const [newMealDescription, setNewMealDescription] = useState('');
+  const [newMealInstructions, setNewMealInstructions] = useState('');
+  const [newMealIngredients, setNewMealIngredients] = useState<RecipeIngredient[]>([]);
   const [selectedMealIds, setSelectedMealIds] = useState<string[]>([]);
   const [quickAddTitle, setQuickAddTitle] = useState('');
   const [sessionMode, setSessionMode] = useState<SessionMode>('home');
@@ -55,6 +67,8 @@ export function Dashboard() {
   const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
   const [editTitle, setEditTitle] = useState('');
   const [editDescription, setEditDescription] = useState('');
+  const [editInstructions, setEditInstructions] = useState('');
+  const [editIngredients, setEditIngredients] = useState<RecipeIngredient[]>([]);
 
   // Animation states
   const [deletingMealIds, setDeletingMealIds] = useState<string[]>([]);
@@ -106,12 +120,22 @@ export function Dashboard() {
     e.preventDefault();
 
     try {
+      const hasRecipe = Boolean(newMealInstructions.trim()) || newMealIngredients.length > 0;
       const meal = activeMode === 'home'
-        ? await mealsApi.create(newMealTitle.trim(), newMealDescription || undefined)
+        ? hasRecipe
+          ? await mealsApi.create(
+              newMealTitle.trim(),
+              newMealDescription || undefined,
+              'meal',
+              { instructions: newMealInstructions, ingredients: newMealIngredients }
+            )
+          : await mealsApi.create(newMealTitle.trim(), newMealDescription || undefined)
         : await mealsApi.create(newMealTitle.trim(), undefined, 'category');
       setMeals((current) => [meal, ...current]);
       setNewMealTitle('');
       setNewMealDescription('');
+      setNewMealInstructions('');
+      setNewMealIngredients([]);
       setShowAddMeal(false);
       if (activeMode === 'takeout') {
         setTakeoutOnboardingDismissed(true);
@@ -124,12 +148,16 @@ export function Dashboard() {
   const openAddMeal = () => {
     setNewMealTitle('');
     setNewMealDescription('');
+    setNewMealInstructions('');
+    setNewMealIngredients([]);
     setShowAddMeal(true);
   };
 
   const closeAddMeal = () => {
     setNewMealTitle('');
     setNewMealDescription('');
+    setNewMealInstructions('');
+    setNewMealIngredients([]);
     setShowAddMeal(false);
   };
 
@@ -175,6 +203,8 @@ export function Dashboard() {
     setEditingMeal(meal);
     setEditTitle(meal.title);
     setEditDescription(meal.description || '');
+    setEditInstructions(meal.instructions || '');
+    setEditIngredients(meal.ingredients?.map((row) => ({ ...row })) || []);
     setShowEditMeal(true);
   };
 
@@ -183,18 +213,27 @@ export function Dashboard() {
     if (!editingMeal) return;
 
     try {
-      await mealsApi.update(editingMeal.id, {
+      const hasLoadedRecipe = editingMeal.instructions !== undefined
+        || editingMeal.ingredients !== undefined;
+      const hasRecipeDraft = Boolean(editInstructions.trim()) || editIngredients.length > 0;
+      const updatedMeal = await mealsApi.update(editingMeal.id, {
         title: editTitle,
         ...(editingMeal.type === 'meal'
           ? { description: editDescription || undefined }
           : {}),
+        ...(editingMeal.type === 'meal' && (hasLoadedRecipe || hasRecipeDraft)
+          ? {
+              instructions: editInstructions || null,
+              ingredients: editIngredients,
+            }
+          : {}),
       });
-      setMeals(meals.map((m) =>
+      setMeals((current) => current.map((m) =>
         m.id === editingMeal.id
           ? {
               ...m,
-              title: editTitle,
-              description: editingMeal.type === 'meal' ? editDescription || null : null,
+              ...updatedMeal,
+              lastSelectedAt: m.lastSelectedAt,
             }
           : m
       ));
@@ -202,6 +241,8 @@ export function Dashboard() {
       setEditingMeal(null);
       setEditTitle('');
       setEditDescription('');
+      setEditInstructions('');
+      setEditIngredients([]);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update meal');
     }
@@ -526,6 +567,14 @@ export function Dashboard() {
                           {meal.description && (
                             <p className="text-gray-600 text-sm mt-1">{meal.description}</p>
                           )}
+                          {meal.type === 'meal'
+                            && (meal.instructions || (meal.ingredients?.length ?? 0) > 0) && (
+                            <p className="text-xs text-primary-600 mt-2">
+                              Recipe · {meal.ingredients?.length ?? 0} ingredient{
+                                (meal.ingredients?.length ?? 0) === 1 ? '' : 's'
+                              }
+                            </p>
+                          )}
                           <p className="text-xs text-gray-400 mt-2">
                             {meal.pickCount > 0 && (
                               <>Selected {meal.pickCount} time{meal.pickCount !== 1 ? 's' : ''} · </>
@@ -700,11 +749,21 @@ export function Dashboard() {
       {/* Add Meal Modal */}
       {showAddMeal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="card w-full max-w-md">
+          <div className="card w-full max-w-lg max-h-[90vh] overflow-y-auto">
             <h3 className="text-xl font-bold mb-4">
               {activeMode === 'home' ? 'Add New Meal' : 'Add Food Category'}
             </h3>
             <form onSubmit={handleAddMeal} className="space-y-4">
+              {activeMode === 'home' && (
+                <RecipePasteImport
+                  onParsed={(recipe) => {
+                    setNewMealTitle(recipe.title);
+                    setNewMealDescription(recipe.description || '');
+                    setNewMealInstructions(recipe.instructions || '');
+                    setNewMealIngredients(recipe.ingredients);
+                  }}
+                />
+              )}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Title *
@@ -731,6 +790,14 @@ export function Dashboard() {
                   placeholder="e.g., Beef tacos with all the fixings"
                 />
               </div>}
+              {activeMode === 'home' && (
+                <RecipeFields
+                  instructions={newMealInstructions}
+                  ingredients={newMealIngredients}
+                  onInstructionsChange={setNewMealInstructions}
+                  onIngredientsChange={setNewMealIngredients}
+                />
+              )}
               <div className="flex gap-3">
                 <button
                   type="button"
@@ -751,11 +818,21 @@ export function Dashboard() {
       {/* Edit Meal Modal */}
       {showEditMeal && editingMeal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="card w-full max-w-md">
+          <div className="card w-full max-w-lg max-h-[90vh] overflow-y-auto">
             <h3 className="text-xl font-bold mb-4">
               {editingMeal.type === 'category' ? 'Edit Category' : 'Edit Meal'}
             </h3>
             <form onSubmit={handleUpdateMeal} className="space-y-4">
+              {editingMeal.type === 'meal' && (
+                <RecipePasteImport
+                  onParsed={(recipe) => {
+                    setEditTitle(recipe.title);
+                    setEditDescription(recipe.description || '');
+                    setEditInstructions(recipe.instructions || '');
+                    setEditIngredients(recipe.ingredients);
+                  }}
+                />
+              )}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Title *
@@ -782,6 +859,14 @@ export function Dashboard() {
                   placeholder="e.g., Beef tacos with all the fixings"
                 />
               </div>}
+              {editingMeal.type === 'meal' && (
+                <RecipeFields
+                  instructions={editInstructions}
+                  ingredients={editIngredients}
+                  onInstructionsChange={setEditInstructions}
+                  onIngredientsChange={setEditIngredients}
+                />
+              )}
               <div className="flex gap-3">
                 <button
                   type="button"

--- a/client/src/pages/Results.recipe.test.tsx
+++ b/client/src/pages/Results.recipe.test.tsx
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { Results } from './Results';
+import { mealsApi, participantApi } from '../api/client';
+
+vi.mock('../api/client', () => ({
+  ApiException: class ApiException extends Error {
+    existingId?: string;
+  },
+  participantApi: {
+    getResults: vi.fn(),
+    getSessionStatus: vi.fn(),
+    closeSession: vi.fn(),
+  },
+  mealsApi: {
+    get: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'host-1', email: 'host@example.com' },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ sessionId: 'session-1' }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const closedResults = {
+  status: 'closed' as const,
+  mode: 'home' as const,
+  isHost: true,
+  results: [{
+    mealId: 'meal-1',
+    title: 'Garlic Soup',
+    description: 'Creamy soup',
+    yesCount: 2,
+    maybeCount: 0,
+    totalVotes: 2,
+    percentage: 100,
+    isUnanimous: true,
+  }],
+};
+
+describe('Results - Host recipe viewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(participantApi.getResults).mockResolvedValue(closedResults);
+    vi.mocked(mealsApi.get).mockResolvedValue({
+      id: 'meal-1',
+      title: 'Garlic Soup',
+      description: 'Creamy soup',
+      instructions: 'Simmer until tender.',
+      ingredients: [{ amount: '2 bulbs', ingredient: 'garlic' }],
+      type: 'meal',
+      pickCount: 1,
+    });
+  });
+
+  it('opens a private recipe when the authenticated host clicks a result name', async () => {
+    render(
+      <BrowserRouter>
+        <Results />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Garlic Soup' }));
+
+    await waitFor(() => expect(mealsApi.get).toHaveBeenCalledWith('meal-1'));
+    const dialog = screen.getByRole('dialog', { name: 'Garlic Soup' });
+    expect(within(dialog).getByText('2 bulbs')).toBeInTheDocument();
+    expect(within(dialog).getByText('Simmer until tender.')).toBeInTheDocument();
+  });
+
+  it('keeps result names non-interactive when the logged-in user is not the host', async () => {
+    vi.mocked(participantApi.getResults).mockResolvedValue({
+      ...closedResults,
+      isHost: false,
+    });
+
+    render(
+      <BrowserRouter>
+        <Results />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('Garlic Soup');
+    expect(screen.queryByRole('button', { name: 'Garlic Soup' })).not.toBeInTheDocument();
+    expect(mealsApi.get).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/Results.tsx
+++ b/client/src/pages/Results.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { participantApi, ResultsResponse, MatchResult, mealsApi, ApiException } from '../api/client';
+import { participantApi, ResultsResponse, MatchResult, mealsApi, ApiException, Meal } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
+import RecipeViewer from '../components/RecipeViewer';
 
 interface Participant {
   id: string;
@@ -23,6 +24,8 @@ export function Results() {
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [closing, setClosing] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [viewingRecipe, setViewingRecipe] = useState<Meal | null>(null);
+  const [loadingRecipeId, setLoadingRecipeId] = useState<string | null>(null);
   const pollTimeoutRef = useRef<number | null>(null);
 
   // Check if user is the creator
@@ -133,6 +136,18 @@ export function Results() {
     sessionStorage.removeItem('creatorToken');
     sessionStorage.removeItem('sessionId');
     setShowSavePrompt(false);
+  };
+
+  const handleViewRecipe = async (mealId: string) => {
+    setLoadingRecipeId(mealId);
+    try {
+      const meal = await mealsApi.get(mealId);
+      if (meal.type === 'meal') setViewingRecipe(meal);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load recipe');
+    } finally {
+      setLoadingRecipeId(null);
+    }
   };
 
   if (loading) {
@@ -329,6 +344,7 @@ export function Results() {
 
   const unanimousResults = results.results?.filter((r) => r.isUnanimous) || [];
   const otherResults = results.results?.filter((r) => !r.isUnanimous) || [];
+  const canViewRecipes = Boolean(user && results.isHost && results.mode === 'home');
 
   return (
     <div className="min-h-screen bg-gray-50 py-8 px-4">
@@ -345,7 +361,20 @@ export function Results() {
             <div className="text-center">
               <span className="text-4xl">🎉</span>
               <h2 className="text-xl font-bold mt-2 text-green-700">Tonight's Pick:</h2>
-              <p className="text-2xl font-bold mt-1">{results.selectedMeal.title}</p>
+              {canViewRecipes ? (
+                <button
+                  type="button"
+                  disabled={loadingRecipeId === results.selectedMeal.id}
+                  onClick={() => handleViewRecipe(results.selectedMeal!.id)}
+                  className="mt-1 text-2xl font-bold text-primary-700 hover:underline disabled:text-gray-400"
+                >
+                  {loadingRecipeId === results.selectedMeal.id
+                    ? 'Loading recipe...'
+                    : results.selectedMeal.title}
+                </button>
+              ) : (
+                <p className="text-2xl font-bold mt-1">{results.selectedMeal.title}</p>
+              )}
               {results.selectedMeal.description && (
                 <p className="text-gray-600 mt-1">{results.selectedMeal.description}</p>
               )}
@@ -362,7 +391,12 @@ export function Results() {
             </h2>
             <div className="space-y-3">
               {unanimousResults.map((result) => (
-                <ResultCard key={result.mealId} result={result} />
+                <ResultCard
+                  key={result.mealId}
+                  result={result}
+                  onViewRecipe={canViewRecipes ? handleViewRecipe : undefined}
+                  recipeLoading={loadingRecipeId === result.mealId}
+                />
               ))}
             </div>
           </section>
@@ -374,7 +408,12 @@ export function Results() {
             <h2 className="text-xl font-bold mb-4">All Results</h2>
             <div className="space-y-3">
               {otherResults.map((result) => (
-                <ResultCard key={result.mealId} result={result} />
+                <ResultCard
+                  key={result.mealId}
+                  result={result}
+                  onViewRecipe={canViewRecipes ? handleViewRecipe : undefined}
+                  recipeLoading={loadingRecipeId === result.mealId}
+                />
               ))}
             </div>
           </section>
@@ -463,15 +502,20 @@ export function Results() {
           </div>
         )}
       </div>
+      {viewingRecipe && (
+        <RecipeViewer meal={viewingRecipe} onClose={() => setViewingRecipe(null)} />
+      )}
     </div>
   );
 }
 
 interface ResultCardProps {
   result: MatchResult;
+  onViewRecipe?: (mealId: string) => void;
+  recipeLoading?: boolean;
 }
 
-function ResultCard({ result }: ResultCardProps) {
+function ResultCard({ result, onViewRecipe, recipeLoading }: ResultCardProps) {
   const [showVoters, setShowVoters] = useState(false);
   const getBarColor = () => {
     if (result.percentage >= 75) return 'bg-green-500';
@@ -489,7 +533,18 @@ function ResultCard({ result }: ResultCardProps) {
     >
       <div className="flex justify-between items-start mb-3">
         <div>
-          <h3 className="font-semibold text-lg">{result.title}</h3>
+          {onViewRecipe ? (
+            <button
+              type="button"
+              disabled={recipeLoading}
+              onClick={() => onViewRecipe(result.mealId)}
+              className="text-left text-lg font-semibold text-primary-700 hover:underline disabled:text-gray-400"
+            >
+              {recipeLoading ? 'Loading recipe...' : result.title}
+            </button>
+          ) : (
+            <h3 className="font-semibold text-lg">{result.title}</h3>
+          )}
           {result.description && (
             <p className="text-gray-600 text-sm mt-1">{result.description}</p>
           )}

--- a/client/src/pages/SessionView.tsx
+++ b/client/src/pages/SessionView.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { sessionsApi, SessionDetails, MatchResult } from '../api/client';
+import { sessionsApi, SessionDetails, MatchResult, mealsApi, Meal } from '../api/client';
 import ConfirmModal from '../components/ConfirmModal';
+import RecipeViewer from '../components/RecipeViewer';
 
 export function SessionView() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -10,6 +11,8 @@ export function SessionView() {
   const [error, setError] = useState('');
   const [copied, setCopied] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [viewingRecipe, setViewingRecipe] = useState<Meal | null>(null);
+  const [loadingRecipeId, setLoadingRecipeId] = useState<string | null>(null);
 
   const loadSession = useCallback(async () => {
     if (!sessionId) return;
@@ -72,6 +75,18 @@ export function SessionView() {
       loadSession();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to select meal');
+    }
+  };
+
+  const handleViewRecipe = async (mealId: string) => {
+    setLoadingRecipeId(mealId);
+    try {
+      const meal = await mealsApi.get(mealId);
+      if (meal.type === 'meal') setViewingRecipe(meal);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load recipe');
+    } finally {
+      setLoadingRecipeId(null);
     }
   };
 
@@ -206,7 +221,20 @@ export function SessionView() {
               <div className="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
                 <p className="text-green-700 font-medium">
                   Selected:{' '}
-                  {session.results.find((r) => r.mealId === session.selectedMealId)?.title}
+                  {session.mode === 'home' ? (
+                    <button
+                      type="button"
+                      disabled={loadingRecipeId === session.selectedMealId}
+                      onClick={() => handleViewRecipe(session.selectedMealId!)}
+                      className="font-semibold text-primary-700 hover:underline disabled:text-gray-400"
+                    >
+                      {loadingRecipeId === session.selectedMealId
+                        ? 'Loading recipe...'
+                        : session.results.find((r) => r.mealId === session.selectedMealId)?.title}
+                    </button>
+                  ) : (
+                    session.results.find((r) => r.mealId === session.selectedMealId)?.title
+                  )}
                 </p>
               </div>
             )}
@@ -220,6 +248,8 @@ export function SessionView() {
                   onSelect={() => handleSelectMeal(result.mealId)}
                   showVoters
                   canSelect={!session.selectedMealId}
+                  onViewRecipe={session.mode === 'home' ? handleViewRecipe : undefined}
+                  recipeLoading={loadingRecipeId === result.mealId}
                 />
               ))}
             </div>
@@ -232,7 +262,18 @@ export function SessionView() {
           <div className="grid gap-3 sm:grid-cols-2">
             {session.meals.map((meal) => (
               <div key={meal.id} className="border rounded-lg p-3">
-                <p className="font-medium">{meal.title}</p>
+                {session.mode === 'home' ? (
+                  <button
+                    type="button"
+                    disabled={loadingRecipeId === meal.id}
+                    onClick={() => handleViewRecipe(meal.id)}
+                    className="font-medium text-primary-700 hover:underline disabled:text-gray-400"
+                  >
+                    {loadingRecipeId === meal.id ? 'Loading recipe...' : meal.title}
+                  </button>
+                ) : (
+                  <p className="font-medium">{meal.title}</p>
+                )}
                 {meal.description && (
                   <p className="text-sm text-gray-500 mt-1">{meal.description}</p>
                 )}
@@ -252,6 +293,9 @@ export function SessionView() {
         onConfirm={closeSession}
         onCancel={() => setShowConfirmModal(false)}
       />
+      {viewingRecipe && (
+        <RecipeViewer meal={viewingRecipe} onClose={() => setViewingRecipe(null)} />
+      )}
     </div>
   );
 }
@@ -262,9 +306,19 @@ interface ResultCardProps {
   onSelect: () => void;
   showVoters?: boolean;
   canSelect?: boolean;
+  onViewRecipe?: (mealId: string) => void;
+  recipeLoading?: boolean;
 }
 
-function ResultCard({ result, isSelected, onSelect, showVoters, canSelect }: ResultCardProps) {
+function ResultCard({
+  result,
+  isSelected,
+  onSelect,
+  showVoters,
+  canSelect,
+  onViewRecipe,
+  recipeLoading,
+}: ResultCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   return (
@@ -276,7 +330,18 @@ function ResultCard({ result, isSelected, onSelect, showVoters, canSelect }: Res
       <div className="flex justify-between items-start">
         <div className="flex-1">
           <div className="flex items-center gap-2">
-            <h3 className="font-semibold text-lg">{result.title}</h3>
+            {onViewRecipe ? (
+              <button
+                type="button"
+                disabled={recipeLoading}
+                onClick={() => onViewRecipe(result.mealId)}
+                className="text-left text-lg font-semibold text-primary-700 hover:underline disabled:text-gray-400"
+              >
+                {recipeLoading ? 'Loading recipe...' : result.title}
+              </button>
+            ) : (
+              <h3 className="font-semibold text-lg">{result.title}</h3>
+            )}
             {result.isUnanimous && (
               <span className="bg-yellow-100 text-yellow-700 text-xs px-2 py-0.5 rounded">
                 Unanimous!

--- a/e2e/meal-management.spec.ts
+++ b/e2e/meal-management.spec.ts
@@ -105,6 +105,70 @@ Simmer until tender.`);
     expect(joinPayload.meals[0]).toMatchObject({ title: 'Garlic Soup' });
     expect(joinPayload.meals[0]).not.toHaveProperty('instructions');
     expect(joinPayload.meals[0]).not.toHaveProperty('ingredients');
+
+    const sessionId = joinPayload.sessionId as string;
+    const mealId = joinPayload.meals[0].id as string;
+    const privateRecipe = await page.evaluate(async (id) => {
+      const response = await fetch(`/api/meals/${id}`);
+      return { status: response.status, body: await response.json() };
+    }, mealId);
+    expect(privateRecipe.status).toBe(200);
+    expect(privateRecipe.body).toMatchObject({
+      instructions: 'Simmer until tender.',
+      ingredients: [
+        { amount: '2 bulbs', ingredient: 'garlic' },
+        { amount: '4oz', ingredient: 'milk' },
+      ],
+    });
+
+    const unauthenticatedRecipe = await request.get(`/api/meals/${mealId}`);
+    expect(unauthenticatedRecipe.status()).toBe(401);
+
+    const swipeResponse = await request.post(`/api/swipes/${sessionId}`, {
+      data: {
+        participantId: joinPayload.participantId,
+        swipes: [{ mealId, vote: 1 }],
+      },
+    });
+    expect(swipeResponse.ok(), await swipeResponse.text()).toBe(true);
+
+    const closeResponse = await page.evaluate(async (id) => {
+      const response = await fetch(`/api/sessions/${id}/close`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      return response.status;
+    }, sessionId);
+    expect(closeResponse).toBe(200);
+
+    const selectResponse = await page.evaluate(async ({ id, selectedMealId }) => {
+      const response = await fetch(`/api/sessions/${id}/select`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mealId: selectedMealId }),
+      });
+      return response.status;
+    }, { id: sessionId, selectedMealId: mealId });
+    expect(selectResponse).toBe(200);
+
+    const publicResults = await request.get(`/api/results/${sessionId}`);
+    expect(publicResults.ok()).toBe(true);
+    const publicResultsPayload = await publicResults.json();
+    expect(publicResultsPayload.results[0]).not.toHaveProperty('instructions');
+    expect(publicResultsPayload.results[0]).not.toHaveProperty('ingredients');
+
+    await page.goto(`/results/${sessionId}`);
+    await page.getByRole('button', { name: 'Garlic Soup' }).first().click();
+    const resultsRecipe = page.getByRole('dialog', { name: 'Garlic Soup' });
+    await expect(resultsRecipe.getByText('2 bulbs')).toBeVisible();
+    await expect(resultsRecipe.getByText('Simmer until tender.')).toBeVisible();
+    await resultsRecipe.getByRole('button', { name: 'Close recipe' }).click();
+
+    await page.goto('/dashboard');
+    const recentSessions = page.locator('section').filter({ hasText: 'Recent Sessions' });
+    await recentSessions.getByRole('button', { name: 'Garlic Soup' }).click();
+    await expect(page.getByRole('dialog', { name: 'Garlic Soup' })).toBeVisible();
   });
 
   test('user can delete single meal with confirmation (#12)', async ({ page }) => {

--- a/e2e/meal-management.spec.ts
+++ b/e2e/meal-management.spec.ts
@@ -61,6 +61,52 @@ test.describe('Meal Management (#17, #12)', () => {
     await expect(page.locator('text=Original Title')).not.toBeVisible();
   });
 
+  test('host can save a private recipe without exposing it to session participants', async ({ page, request }) => {
+    const uniqueEmail = `test-recipe-${Date.now()}@example.com`;
+    await registerAndGoToDashboard(page, uniqueEmail);
+
+    await page.getByRole('button', { name: 'Add Meal' }).click();
+    const addModal = page.locator('.card:has(h3:has-text("Add New Meal"))');
+    await addModal.getByRole('button', { name: 'Paste a full recipe' }).click();
+    await addModal.getByLabel('Recipe text to parse').fill(`Title: Garlic Soup
+Description: Creamy roasted garlic soup
+Ingredients:
+2 bulbs | garlic
+4oz | milk
+Instructions:
+Simmer until tender.`);
+    await addModal.getByRole('button', { name: 'Fill recipe form' }).click();
+    await expect(addModal.locator('input[placeholder="e.g., Tacos"]')).toHaveValue('Garlic Soup');
+    await expect(addModal.getByLabel('Ingredient 2 name')).toHaveValue('milk');
+    await addModal.getByRole('button', { name: 'Add Meal' }).click();
+
+    await expect(page.getByText('Recipe · 2 ingredients')).toBeVisible();
+    await page.reload();
+    await page.getByTitle('Edit meal').click();
+    const editModal = page.locator('.card:has(h3:has-text("Edit Meal"))');
+    await expect(editModal.locator('textarea[placeholder="Describe how to make this meal"]'))
+      .toHaveValue('Simmer until tender.');
+    await expect(editModal.getByLabel('Ingredient 1 amount')).toHaveValue('2 bulbs');
+    await expect(editModal.getByLabel('Ingredient 1 name')).toHaveValue('garlic');
+    await expect(editModal.getByLabel('Ingredient 2 amount')).toHaveValue('4oz');
+    await expect(editModal.getByLabel('Ingredient 2 name')).toHaveValue('milk');
+    await editModal.getByRole('button', { name: 'Cancel' }).click();
+
+    await page.getByRole('button', { name: 'Create Session' }).click();
+    await page.getByRole('button', { name: 'Create (1 options)' }).click();
+    const inviteUrl = await page.locator('input[readonly]').first().inputValue();
+    const inviteCode = inviteUrl.split('/join/')[1];
+
+    const joinResponse = await request.post(`/api/join/${inviteCode}`, {
+      data: { displayName: 'Recipe privacy check' },
+    });
+    expect(joinResponse.ok()).toBe(true);
+    const joinPayload = await joinResponse.json();
+    expect(joinPayload.meals[0]).toMatchObject({ title: 'Garlic Soup' });
+    expect(joinPayload.meals[0]).not.toHaveProperty('instructions');
+    expect(joinPayload.meals[0]).not.toHaveProperty('ingredients');
+  });
+
   test('user can delete single meal with confirmation (#12)', async ({ page }) => {
     const uniqueEmail = `test-delete-${Date.now()}@example.com`;
     await registerAndGoToDashboard(page, uniqueEmail);

--- a/server/src/db/schema.test.ts
+++ b/server/src/db/schema.test.ts
@@ -4,14 +4,17 @@ import initSqlJs from 'sql.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const testDatabasePath = path.join(__dirname, '../../data/schema-migration-test.db');
+const freshDatabasePath = path.join(__dirname, '../../data/schema-fresh-test.db');
 
 describe('database schema migrations', () => {
   afterEach(() => {
     delete process.env.DATABASE_PATH;
     vi.resetModules();
-    if (fs.existsSync(testDatabasePath)) {
-      fs.rmSync(testDatabasePath);
-    }
+    [testDatabasePath, freshDatabasePath].forEach((databasePath) => {
+      if (fs.existsSync(databasePath)) {
+        fs.rmSync(databasePath);
+      }
+    });
   });
 
   it('migrates existing meals and sessions to the mode-aware schema', async () => {
@@ -68,7 +71,39 @@ describe('database schema migrations', () => {
     expect(getOne<{ type: string }>('SELECT type FROM meals WHERE id = ?', ['meal-1'])?.type)
       .toBe('meal');
 
+    const mealColumns = migratedDatabase.exec('PRAGMA table_info(meals)')[0].values;
+    expect(mealColumns.some((column) => column[1] === 'instructions')).toBe(true);
+    const ingredientColumns = migratedDatabase.exec('PRAGMA table_info(meal_ingredients)')[0].values;
+    expect(ingredientColumns.map((column) => column[1])).toEqual([
+      'id',
+      'meal_id',
+      'amount',
+      'ingredient',
+      'display_order',
+    ]);
+
     const indexes = migratedDatabase.exec('PRAGMA index_list(meals)')[0].values;
     expect(indexes.some((index) => index[1] === 'idx_meals_host_type_archived')).toBe(true);
+    const ingredientIndexes = migratedDatabase.exec('PRAGMA index_list(meal_ingredients)')[0].values;
+    expect(ingredientIndexes.some((index) => index[1] === 'idx_meal_ingredients_meal_order'))
+      .toBe(true);
+  });
+
+  it('creates recipe storage in a fresh database', async () => {
+    process.env.DATABASE_PATH = freshDatabasePath;
+    vi.resetModules();
+    const { initializeDatabase } = await import('./schema');
+    const freshDatabase = await initializeDatabase();
+
+    const mealColumns = freshDatabase.exec('PRAGMA table_info(meals)')[0].values;
+    expect(mealColumns.some((column) => column[1] === 'instructions')).toBe(true);
+    const ingredientColumns = freshDatabase.exec('PRAGMA table_info(meal_ingredients)')[0].values;
+    expect(ingredientColumns.map((column) => column[1])).toEqual([
+      'id',
+      'meal_id',
+      'amount',
+      'ingredient',
+      'display_order',
+    ]);
   });
 });

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -48,6 +48,20 @@ function runMigrations(database: Database): void {
     database.run('ALTER TABLE hosts ADD COLUMN takeout_onboarding_dismissed INTEGER NOT NULL DEFAULT 0');
   }
 
+  if (!columnExists(database, 'meals', 'instructions')) {
+    database.run('ALTER TABLE meals ADD COLUMN instructions TEXT');
+  }
+
+  database.run(`
+    CREATE TABLE IF NOT EXISTS meal_ingredients (
+      id TEXT PRIMARY KEY,
+      meal_id TEXT NOT NULL REFERENCES meals(id),
+      amount TEXT NOT NULL DEFAULT '',
+      ingredient TEXT NOT NULL,
+      display_order INTEGER NOT NULL
+    )
+  `);
+
   database.run("UPDATE meals SET type = 'meal' WHERE type IS NULL OR TRIM(type) = ''");
   database.run(`
     UPDATE hosts
@@ -61,6 +75,10 @@ function runMigrations(database: Database): void {
   database.run(`
     CREATE INDEX IF NOT EXISTS idx_meals_host_type_archived
     ON meals(host_id, type, archived)
+  `);
+  database.run(`
+    CREATE INDEX IF NOT EXISTS idx_meal_ingredients_meal_order
+    ON meal_ingredients(meal_id, display_order)
   `);
 
   saveDatabase();
@@ -91,12 +109,22 @@ function createTables(database: Database): void {
       host_id TEXT NOT NULL REFERENCES hosts(id),
       title TEXT NOT NULL,
       description TEXT,
+      instructions TEXT,
       type TEXT DEFAULT 'meal',
       archived INTEGER DEFAULT 0,
       pick_count INTEGER DEFAULT 0,
       temporary INTEGER DEFAULT 0,
       creator_token TEXT,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- Private recipe ingredients for home meals
+    CREATE TABLE IF NOT EXISTS meal_ingredients (
+      id TEXT PRIMARY KEY,
+      meal_id TEXT NOT NULL REFERENCES meals(id),
+      amount TEXT NOT NULL DEFAULT '',
+      ingredient TEXT NOT NULL,
+      display_order INTEGER NOT NULL
     );
 
     -- Swipe sessions
@@ -150,6 +178,7 @@ function createTables(database: Database): void {
     -- Create indexes for better query performance
     CREATE INDEX IF NOT EXISTS idx_meals_host_id ON meals(host_id);
     CREATE INDEX IF NOT EXISTS idx_meals_host_type_archived ON meals(host_id, type, archived);
+    CREATE INDEX IF NOT EXISTS idx_meal_ingredients_meal_order ON meal_ingredients(meal_id, display_order);
     CREATE INDEX IF NOT EXISTS idx_sessions_host_id ON sessions(host_id);
     CREATE INDEX IF NOT EXISTS idx_sessions_invite_code ON sessions(invite_code);
     CREATE INDEX IF NOT EXISTS idx_session_meals_session_id ON session_meals(session_id);

--- a/server/src/routes/meals.ts
+++ b/server/src/routes/meals.ts
@@ -1,8 +1,14 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { runQuery, getOne, getAll } from '../db/schema';
-import { Meal, MealType, CreateMealRequest } from '../types';
+import { runQuery, getOne, getAll, getDatabase, saveDatabase } from '../db/schema';
+import { Meal, MealIngredient, MealType, CreateMealRequest } from '../types';
 import { requireAuth } from '../middleware/auth';
+import {
+  normalizeIngredients,
+  normalizeInstructions,
+  parseRecipeText,
+  RecipeValidationError,
+} from '../services/recipe';
 
 const router = Router();
 
@@ -14,8 +20,81 @@ function getRequestedType(value: unknown): MealType | undefined {
     : undefined;
 }
 
+function getMealIngredients(mealId: string): MealIngredient[] {
+  return getAll<MealIngredient>(
+    `SELECT amount, ingredient
+     FROM meal_ingredients
+     WHERE meal_id = ?
+     ORDER BY display_order`,
+    [mealId]
+  );
+}
+
+function toLibraryMealResponse(meal: Meal, includeArchived = false) {
+  const response = {
+    id: meal.id,
+    title: meal.title,
+    description: meal.description,
+    type: meal.type,
+    ...(includeArchived ? { archived: meal.archived === 1 } : {}),
+    pickCount: meal.pick_count,
+    createdAt: meal.created_at,
+    lastSelectedAt: meal.last_selected_at ?? null,
+  };
+
+  return meal.type === 'meal'
+    ? {
+        ...response,
+        instructions: meal.instructions ?? null,
+        ingredients: getMealIngredients(meal.id),
+      }
+    : response;
+}
+
+function addIngredients(
+  database: ReturnType<typeof getDatabase>,
+  mealId: string,
+  ingredients: MealIngredient[]
+): void {
+  ingredients.forEach((row, index) => {
+    database.run(
+      `INSERT INTO meal_ingredients (id, meal_id, amount, ingredient, display_order)
+       VALUES (?, ?, ?, ?, ?)`,
+      [uuidv4(), mealId, row.amount, row.ingredient, index]
+    );
+  });
+}
+
+function runTransaction(action: (database: ReturnType<typeof getDatabase>) => void): void {
+  const database = getDatabase();
+  database.run('BEGIN TRANSACTION');
+  try {
+    action(database);
+    database.run('COMMIT');
+  } catch (error) {
+    database.run('ROLLBACK');
+    throw error;
+  }
+  saveDatabase();
+}
+
 // All meal routes require authentication
 router.use(requireAuth);
+
+// POST /api/meals/parse-recipe - Parse a full recipe without saving it
+router.post('/parse-recipe', (req, res) => {
+  try {
+    res.json(parseRecipeText(req.body?.text));
+  } catch (error) {
+    if (error instanceof RecipeValidationError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+
+    console.error('Parse recipe error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
 
 // GET /api/meals - List host's meals (excludes archived)
 router.get('/', (req, res) => {
@@ -31,7 +110,7 @@ router.get('/', (req, res) => {
       ? [req.session.hostId, requestedType]
       : [req.session.hostId];
     const meals = getAll<Meal>(
-      `SELECT id, title, description, type, archived, pick_count, created_at,
+      `SELECT id, title, description, instructions, type, archived, pick_count, created_at,
         (SELECT MAX(selected_at) FROM session_history WHERE selected_meal_id = meals.id) AS last_selected_at
        FROM meals
        WHERE host_id = ? AND archived = 0${typeFilter}
@@ -39,15 +118,7 @@ router.get('/', (req, res) => {
       params
     );
 
-    res.json(meals.map(meal => ({
-      id: meal.id,
-      title: meal.title,
-      description: meal.description,
-      type: meal.type,
-      pickCount: meal.pick_count,
-      createdAt: meal.created_at,
-      lastSelectedAt: meal.last_selected_at ?? null,
-    })));
+    res.json(meals.map(meal => toLibraryMealResponse(meal)));
   } catch (error) {
     console.error('Get meals error:', error);
     res.status(500).json({ error: 'Internal server error' });
@@ -68,7 +139,7 @@ router.get('/all', (req, res) => {
       ? [req.session.hostId, requestedType]
       : [req.session.hostId];
     const meals = getAll<Meal>(
-      `SELECT id, title, description, type, archived, pick_count, created_at,
+      `SELECT id, title, description, instructions, type, archived, pick_count, created_at,
         (SELECT MAX(selected_at) FROM session_history WHERE selected_meal_id = meals.id) AS last_selected_at
        FROM meals
        WHERE host_id = ?${typeFilter}
@@ -76,16 +147,7 @@ router.get('/all', (req, res) => {
       params
     );
 
-    res.json(meals.map(meal => ({
-      id: meal.id,
-      title: meal.title,
-      description: meal.description,
-      type: meal.type,
-      archived: meal.archived === 1,
-      pickCount: meal.pick_count,
-      createdAt: meal.created_at,
-      lastSelectedAt: meal.last_selected_at ?? null,
-    })));
+    res.json(meals.map(meal => toLibraryMealResponse(meal, true)));
   } catch (error) {
     console.error('Get all meals error:', error);
     res.status(500).json({ error: 'Internal server error' });
@@ -95,7 +157,13 @@ router.get('/all', (req, res) => {
 // POST /api/meals - Create meal
 router.post('/', (req, res) => {
   try {
-    const { title, description, type = 'meal' } = req.body as CreateMealRequest;
+    const {
+      title,
+      description,
+      type = 'meal',
+      instructions,
+      ingredients,
+    } = req.body as CreateMealRequest;
 
     if (!title || title.trim().length === 0) {
       res.status(400).json({ error: 'Title is required' });
@@ -105,6 +173,29 @@ router.post('/', (req, res) => {
     if (!libraryTypes.includes(type)) {
       res.status(400).json({ error: 'Type must be meal or category' });
       return;
+    }
+
+    const hasRecipeFields = instructions !== undefined || ingredients !== undefined;
+    if (type === 'category' && hasRecipeFields) {
+      res.status(400).json({ error: 'Food categories do not support recipes' });
+      return;
+    }
+
+    let normalizedInstructions: string | null = null;
+    let normalizedIngredients: MealIngredient[] = [];
+    try {
+      if (instructions !== undefined) {
+        normalizedInstructions = normalizeInstructions(instructions);
+      }
+      if (ingredients !== undefined) {
+        normalizedIngredients = normalizeIngredients(ingredients);
+      }
+    } catch (error) {
+      if (error instanceof RecipeValidationError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      throw error;
     }
 
     const normalizedTitle = title.trim();
@@ -125,25 +216,31 @@ router.post('/', (req, res) => {
     const id = uuidv4();
     const normalizedDescription = type === 'category' ? null : description?.trim() || null;
 
-    runQuery(
-      'INSERT INTO meals (id, host_id, title, description, type) VALUES (?, ?, ?, ?, ?)',
-      [id, req.session.hostId, normalizedTitle, normalizedDescription, type]
-    );
-
-    if (type === 'category') {
-      runQuery(
-        'UPDATE hosts SET takeout_onboarding_dismissed = 1 WHERE id = ?',
-        [req.session.hostId]
+    runTransaction((database) => {
+      database.run(
+        `INSERT INTO meals (id, host_id, title, description, instructions, type)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [
+          id,
+          req.session.hostId,
+          normalizedTitle,
+          normalizedDescription,
+          normalizedInstructions,
+          type,
+        ]
       );
-    }
+      addIngredients(database, id, normalizedIngredients);
 
-    res.status(201).json({
-      id,
-      title: normalizedTitle,
-      description: normalizedDescription,
-      type,
-      pickCount: 0,
+      if (type === 'category') {
+        database.run(
+          'UPDATE hosts SET takeout_onboarding_dismissed = 1 WHERE id = ?',
+          [req.session.hostId]
+        );
+      }
     });
+
+    const created = getOne<Meal>('SELECT * FROM meals WHERE id = ?', [id]);
+    res.status(201).json(toLibraryMealResponse(created!));
   } catch (error) {
     console.error('Create meal error:', error);
     res.status(500).json({ error: 'Internal server error' });
@@ -154,7 +251,7 @@ router.post('/', (req, res) => {
 router.patch('/:id', (req, res) => {
   try {
     const { id } = req.params;
-    const { title, description } = req.body;
+    const { title, description, instructions, ingredients } = req.body;
 
     // Verify ownership
     const meal = getOne<Meal>(
@@ -164,6 +261,12 @@ router.patch('/:id', (req, res) => {
 
     if (!meal) {
       res.status(404).json({ error: 'Meal not found' });
+      return;
+    }
+
+    const hasRecipeFields = instructions !== undefined || ingredients !== undefined;
+    if (meal.type === 'category' && hasRecipeFields) {
+      res.status(400).json({ error: 'Food categories do not support recipes' });
       return;
     }
 
@@ -202,23 +305,44 @@ router.patch('/:id', (req, res) => {
       params.push(description?.trim() || null);
     }
 
-    if (updates.length === 0) {
+    let normalizedIngredients: MealIngredient[] | undefined;
+    try {
+      if (instructions !== undefined) {
+        updates.push('instructions = ?');
+        params.push(normalizeInstructions(instructions));
+      }
+      if (ingredients !== undefined) {
+        normalizedIngredients = normalizeIngredients(ingredients);
+      }
+    } catch (error) {
+      if (error instanceof RecipeValidationError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      throw error;
+    }
+
+    if (updates.length === 0 && normalizedIngredients === undefined) {
       res.status(400).json({ error: 'No fields to update' });
       return;
     }
 
-    params.push(id);
-    runQuery(`UPDATE meals SET ${updates.join(', ')} WHERE id = ?`, params);
+    runTransaction((database) => {
+      if (updates.length > 0) {
+        database.run(
+          `UPDATE meals SET ${updates.join(', ')} WHERE id = ?`,
+          [...params, id]
+        );
+      }
+      if (normalizedIngredients !== undefined) {
+        database.run('DELETE FROM meal_ingredients WHERE meal_id = ?', [id]);
+        addIngredients(database, id, normalizedIngredients);
+      }
+    });
 
     // Return updated meal
     const updated = getOne<Meal>('SELECT * FROM meals WHERE id = ?', [id]);
-    res.json({
-      id: updated!.id,
-      title: updated!.title,
-      description: updated!.description,
-      type: updated!.type,
-      pickCount: updated!.pick_count,
-    });
+    res.json(toLibraryMealResponse(updated!));
   } catch (error) {
     console.error('Update meal error:', error);
     res.status(500).json({ error: 'Internal server error' });

--- a/server/src/routes/meals.ts
+++ b/server/src/routes/meals.ts
@@ -154,6 +154,29 @@ router.get('/all', (req, res) => {
   }
 });
 
+// GET /api/meals/:id - Get one host-owned meal, including private recipe data
+router.get('/:id', (req, res) => {
+  try {
+    const meal = getOne<Meal>(
+      `SELECT id, title, description, instructions, type, archived, pick_count, created_at,
+        (SELECT MAX(selected_at) FROM session_history WHERE selected_meal_id = meals.id) AS last_selected_at
+       FROM meals
+       WHERE id = ? AND host_id = ?`,
+      [req.params.id, req.session.hostId]
+    );
+
+    if (!meal) {
+      res.status(404).json({ error: 'Meal not found' });
+      return;
+    }
+
+    res.json(toLibraryMealResponse(meal, true));
+  } catch (error) {
+    console.error('Get meal error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // POST /api/meals - Create meal
 router.post('/', (req, res) => {
   try {

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -14,12 +14,20 @@ router.use(requireAuth);
 // GET /api/sessions - List host's sessions
 router.get('/', (req, res) => {
   try {
-    const sessions = getAll<Session & { meal_count: number; participant_count: number }>(
+    const sessions = getAll<Session & {
+      meal_count: number;
+      participant_count: number;
+      selected_meal_title: string | null;
+      selected_meal_type: Meal['type'] | null;
+    }>(
       `SELECT
         s.*,
+        selected_meal.title as selected_meal_title,
+        selected_meal.type as selected_meal_type,
         (SELECT COUNT(*) FROM session_meals WHERE session_id = s.id) as meal_count,
         (SELECT COUNT(*) FROM participants WHERE session_id = s.id) as participant_count
       FROM sessions s
+      LEFT JOIN meals selected_meal ON selected_meal.id = s.selected_meal_id
       WHERE s.host_id = ?
       ORDER BY s.created_at DESC`,
       [req.session.hostId]
@@ -31,6 +39,13 @@ router.get('/', (req, res) => {
       status: session.status,
       mode: session.mode,
       selectedMealId: session.selected_meal_id,
+      selectedMeal: session.selected_meal_id && session.selected_meal_title && session.selected_meal_type
+        ? {
+            id: session.selected_meal_id,
+            title: session.selected_meal_title,
+            type: session.selected_meal_type,
+          }
+        : null,
       mealCount: session.meal_count,
       participantCount: session.participant_count,
       createdAt: session.created_at,

--- a/server/src/services/recipe.test.ts
+++ b/server/src/services/recipe.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeIngredients,
+  normalizeInstructions,
+  parseRecipeText,
+  RecipeValidationError,
+} from './recipe';
+
+describe('recipe normalization', () => {
+  it('preserves free-text amounts while trimming ingredient rows', () => {
+    expect(normalizeIngredients([
+      { amount: ' 2 bulbs ', ingredient: ' garlic ' },
+      { amount: '4oz', ingredient: 'milk' },
+    ])).toEqual([
+      { amount: '2 bulbs', ingredient: 'garlic' },
+      { amount: '4oz', ingredient: 'milk' },
+    ]);
+  });
+
+  it('allows an empty amount but requires an ingredient name', () => {
+    expect(normalizeIngredients([{ amount: '', ingredient: 'salt' }])).toEqual([
+      { amount: '', ingredient: 'salt' },
+    ]);
+    expect(() => normalizeIngredients([{ amount: '1 cup', ingredient: ' ' }]))
+      .toThrow(RecipeValidationError);
+  });
+
+  it('normalizes blank instructions to null', () => {
+    expect(normalizeInstructions('  Mix everything.  ')).toBe('Mix everything.');
+    expect(normalizeInstructions('  ')).toBeNull();
+  });
+
+  it('parses the deterministic full-recipe paste format', () => {
+    expect(parseRecipeText(`
+Title: Garlic Soup
+Description: Creamy roasted garlic soup
+Ingredients:
+2 bulbs | garlic
+4oz | milk
+to taste | salt
+Instructions:
+Roast the garlic.
+Blend and simmer.
+    `)).toEqual({
+      title: 'Garlic Soup',
+      description: 'Creamy roasted garlic soup',
+      instructions: 'Roast the garlic.\nBlend and simmer.',
+      ingredients: [
+        { amount: '2 bulbs', ingredient: 'garlic' },
+        { amount: '4oz', ingredient: 'milk' },
+        { amount: 'to taste', ingredient: 'salt' },
+      ],
+    });
+  });
+
+  it('accepts an LLM code fence and an empty amount', () => {
+    expect(parseRecipeText(`\`\`\`text
+Title: Toast
+Ingredients:
+ | bread
+Instructions:
+Toast it.
+\`\`\``)).toMatchObject({
+      title: 'Toast',
+      ingredients: [{ amount: '', ingredient: 'bread' }],
+    });
+  });
+
+  it('reports malformed ingredient rows with their line number', () => {
+    expect(() => parseRecipeText(`Title: Soup
+Ingredients:
+2 bulbs garlic`)).toThrow('line 3 must use "amount | ingredient"');
+  });
+});

--- a/server/src/services/recipe.ts
+++ b/server/src/services/recipe.ts
@@ -1,0 +1,149 @@
+import { MealIngredient, ParsedRecipe } from '../types';
+
+export class RecipeValidationError extends Error {}
+
+export function normalizeInstructions(value: unknown): string | null {
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new RecipeValidationError('Instructions must be text');
+  }
+
+  return value.trim() || null;
+}
+
+export function normalizeIngredients(value: unknown): MealIngredient[] {
+  if (!Array.isArray(value)) {
+    throw new RecipeValidationError('Ingredients must be an array');
+  }
+
+  return value.map((row, index) => {
+    if (!row || typeof row !== 'object') {
+      throw new RecipeValidationError(`Ingredient ${index + 1} must be an object`);
+    }
+
+    const amount = (row as Record<string, unknown>).amount;
+    const ingredient = (row as Record<string, unknown>).ingredient;
+    if (typeof amount !== 'string' || typeof ingredient !== 'string') {
+      throw new RecipeValidationError(
+        `Ingredient ${index + 1} must have text amount and ingredient fields`
+      );
+    }
+
+    const normalizedIngredient = ingredient.trim();
+    if (!normalizedIngredient) {
+      throw new RecipeValidationError(`Ingredient ${index + 1} cannot be empty`);
+    }
+
+    return {
+      amount: amount.trim(),
+      ingredient: normalizedIngredient,
+    };
+  });
+}
+
+export function parseRecipeText(value: unknown): ParsedRecipe {
+  if (typeof value !== 'string') {
+    throw new RecipeValidationError('Recipe text is required');
+  }
+
+  let text = value.replace(/\r\n?/g, '\n').trim();
+  if (text.length > 50_000) {
+    throw new RecipeValidationError('Recipe text is too long');
+  }
+
+  const fenced = text.match(/^```[^\n]*\n([\s\S]*?)\n```$/);
+  if (fenced) text = fenced[1].trim();
+
+  const lines = text.split('\n');
+  let title: string | null = null;
+  let description: string | null = null;
+  let sawDescription = false;
+  let section: 'header' | 'ingredients' | 'instructions' = 'header';
+  let sawIngredients = false;
+  let sawInstructions = false;
+  const ingredientRows: MealIngredient[] = [];
+  const instructionLines: string[] = [];
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+
+    if (/^Ingredients:\s*$/i.test(trimmed)) {
+      if (sawIngredients || sawInstructions) {
+        throw new RecipeValidationError(`Unexpected Ingredients section on line ${index + 1}`);
+      }
+      sawIngredients = true;
+      section = 'ingredients';
+      return;
+    }
+
+    if (/^Instructions:\s*$/i.test(trimmed)) {
+      if (!sawIngredients || sawInstructions) {
+        throw new RecipeValidationError(`Unexpected Instructions section on line ${index + 1}`);
+      }
+      sawInstructions = true;
+      section = 'instructions';
+      return;
+    }
+
+    if (section === 'header') {
+      if (!trimmed) return;
+
+      const titleMatch = trimmed.match(/^Title:\s*(.*)$/i);
+      if (titleMatch) {
+        if (title !== null) {
+          throw new RecipeValidationError(`Duplicate Title on line ${index + 1}`);
+        }
+        title = titleMatch[1].trim();
+        return;
+      }
+
+      const descriptionMatch = trimmed.match(/^Description:\s*(.*)$/i);
+      if (descriptionMatch) {
+        if (sawDescription) {
+          throw new RecipeValidationError(`Duplicate Description on line ${index + 1}`);
+        }
+        sawDescription = true;
+        description = descriptionMatch[1].trim() || null;
+        return;
+      }
+
+      throw new RecipeValidationError(`Unexpected header on line ${index + 1}`);
+    }
+
+    if (section === 'ingredients') {
+      if (!trimmed) return;
+
+      const delimiterIndex = line.indexOf('|');
+      if (delimiterIndex === -1) {
+        throw new RecipeValidationError(
+          `Ingredient ${ingredientRows.length + 1} on line ${index + 1} must use "amount | ingredient"`
+        );
+      }
+
+      ingredientRows.push({
+        amount: line.slice(0, delimiterIndex),
+        ingredient: line.slice(delimiterIndex + 1),
+      });
+      return;
+    }
+
+    instructionLines.push(line);
+  });
+
+  if (!title) {
+    throw new RecipeValidationError('Recipe text must include a non-empty Title');
+  }
+  if (!sawIngredients) {
+    throw new RecipeValidationError('Recipe text must include an Ingredients section');
+  }
+  if (ingredientRows.length === 0) {
+    throw new RecipeValidationError('Recipe text must include at least one ingredient');
+  }
+
+  return {
+    title,
+    description,
+    instructions: normalizeInstructions(instructionLines.join('\n')),
+    ingredients: normalizeIngredients(ingredientRows),
+  };
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -16,6 +16,7 @@ export interface Meal {
   host_id: string;
   title: string;
   description: string | null;
+  instructions: string | null;
   type: MealType;
   archived: number; // SQLite boolean (0 or 1)
   pick_count: number;
@@ -23,6 +24,18 @@ export interface Meal {
   creator_token: string | null;
   created_at: string;
   last_selected_at?: string | null;
+}
+
+export interface MealIngredient {
+  amount: string;
+  ingredient: string;
+}
+
+export interface ParsedRecipe {
+  title: string;
+  description: string | null;
+  instructions: string | null;
+  ingredients: MealIngredient[];
 }
 
 export interface Session {
@@ -91,6 +104,8 @@ export interface CreateMealRequest {
   title: string;
   description?: string;
   type?: MealType;
+  instructions?: string | null;
+  ingredients?: MealIngredient[];
 }
 
 export interface CreateSessionRequest {


### PR DESCRIPTION
## Problem and outcome

Home meals only supported a title and description, so hosts could not keep the recipe beside the meal, enter one efficiently, or bring it back into view after choosing what to cook. This adds private recipe details to authenticated home-meal libraries and a readable host-only recipe view while keeping every participant-facing session payload unchanged.

## Implemented first slice

- Add recipe instructions plus ordered ingredient rows containing only free-text `amount` and `ingredient` fields.
- Create, edit, remove, and reorder recipe rows from the authenticated dashboard.
- Accept a deterministic, LLM-friendly full-recipe paste format and fill the normal editable form after validation.
- Keep saving as a separate user action so imported content can be reviewed first.
- Let authenticated hosts click home-meal names to open a read-only recipe panel from the library, completed results, host session details, and selected meals in Recent Sessions.

## Product decisions and exclusions

- Recipes are private host-library data and are excluded from join, swipe, session, and result payloads.
- Recipe names become interactive only for the authenticated session owner; other result viewers continue to receive and see the existing public result shape.
- Takeout categories reject recipe fields and do not open the recipe viewer.
- Ingredient amounts remain exactly as entered; this slice does not parse units, consolidate quantities, or infer structured food data.
- The paste flow is deterministic and does not call an LLM.
- Servings, images, weekly planning, and shopping-list generation are deferred.

## Implementation notes

- Add an optional `meals.instructions` column through both fresh-schema creation and the additive migration path.
- Add `meal_ingredients` with stable position ordering and cascading meal deletion.
- Write meal and ingredient changes transactionally to avoid partial recipe updates.
- Add an authenticated `/api/meals/parse-recipe` endpoint with a 50,000-character limit, optional Markdown code-fence handling, strict section parsing, and line-specific validation errors.
- Load read-only recipes through an authenticated `/api/meals/:id` endpoint that checks host ownership and can still retrieve an archived selected meal.
- Add only the selected meal ID, title, and type to the authenticated Recent Sessions response; instructions and ingredients remain in the dedicated meal response.

## Verification

- `npm test` — 129 client and server tests passed.
- `npm run lint` — passed.
- `npm --prefix client run build` — passed.
- `npm --prefix server run build` — passed.
- Focused Playwright recipe import, persistence, results/recent-session viewing, ownership enforcement, and public-payload privacy flow — passed.

## Deferred follow-ups

- Weekly planning and shopping lists moved to `Next` now that recipe data exists.
- Meal pictures remain in `Later` pending storage and public-visibility decisions.
