### PR TITLE
Promote selected winners in recent sessions

### DIFF
--- a/Ideas.md
+++ b/Ideas.md
@@ -8,8 +8,6 @@ Keep this file lean. Add rough thoughts under `## Ungroomed ideas`; keep active 
 
 ## Now
 
-- **Make selected winners prominent in recent sessions** — On closed sessions with a final selection, lead with the winning meal/category name and retain the invite code as secondary session metadata. Do not invent a winner for sessions without a final selection.
-
 - **Private library notes** — Let hosts add one private free-text note to each home meal or takeout category, opened deliberately from the library rather than shown on cards. Keep notes out of session, swipe, and public-result payloads; defer restaurant/dish-specific notes until a real restaurant model exists.
 
 - **Library export and import** — Transfer active home meals and takeout categories with versioned JSON, validation, preview, and duplicate reporting. Do not transfer IDs, ownership, tokens, counts, or history.

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -1262,10 +1262,40 @@ Blend and simmer.`;
 
     const recentSessions = (await screen.findByText('Recent Sessions')).closest('section');
     expect(recentSessions).not.toBeNull();
+    expect(within(recentSessions!).getByRole('heading', { name: /Winner:\s*Garlic soup/ }))
+      .toBeInTheDocument();
+    expect(within(recentSessions!).getByText('Invite code:', { exact: false })).toBeInTheDocument();
+    expect(within(recentSessions!).getByText('ABC123')).toBeInTheDocument();
     fireEvent.click(within(recentSessions!).getByRole('button', { name: 'Garlic soup' }));
 
     await waitFor(() => expect(mealsApi.get).toHaveBeenCalledWith('recipe-1'));
     expect(screen.getByRole('dialog', { name: 'Garlic soup' })).toBeInTheDocument();
+  });
+
+  it('does not show a winner heading when a closed session has no final selection', async () => {
+    vi.mocked(sessionsApi.list).mockResolvedValue([{
+      id: 'session-1',
+      inviteCode: 'ABC123',
+      status: 'closed',
+      mode: 'home',
+      selectedMealId: null,
+      selectedMeal: null,
+      mealCount: 1,
+      participantCount: 2,
+      createdAt: '2024-01-01',
+      closedAt: '2024-01-01',
+    }]);
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    const recentSessions = (await screen.findByText('Recent Sessions')).closest('section');
+    expect(recentSessions).not.toBeNull();
+    expect(within(recentSessions!).queryByRole('heading', { name: /Winner:/ })).not.toBeInTheDocument();
+    expect(within(recentSessions!).getByText('ABC123')).toBeInTheDocument();
   });
 
   it('does not show recipe fields for takeout categories', async () => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -686,45 +686,64 @@ export function Dashboard() {
                 >
                   <div className="flex justify-between items-center">
                     <div>
-                      <div className="flex items-center gap-2">
-                        <span className="font-mono font-bold text-lg">{session.inviteCode}</span>
-                        <span className="px-2 py-0.5 rounded text-xs font-medium bg-orange-50 text-orange-700">
-                          {session.mode === 'takeout' ? 'Order out' : 'Cook at home'}
-                        </span>
-                        <span
-                          className={`px-2 py-0.5 rounded text-xs font-medium ${
-                            session.status === 'open'
-                              ? 'bg-green-100 text-green-700'
-                              : 'bg-gray-100 text-gray-700'
-                          }`}
-                        >
-                          {session.status}
-                        </span>
-                      </div>
-                      <p className="text-sm text-gray-500 mt-1">
-                        {session.mealCount} options · {session.participantCount} participants
-                      </p>
-                      {session.selectedMeal && (
-                        <p className="mt-1 text-sm text-gray-600">
-                          Selected:{' '}
-                          {session.selectedMeal.type === 'meal' ? (
-                            <button
-                              type="button"
-                              disabled={loadingRecipeId === session.selectedMeal.id}
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                openRecipe(session.selectedMeal!.id);
-                              }}
-                              className="font-medium text-primary-700 hover:underline disabled:text-gray-400"
+                      {session.status === 'closed' && session.selectedMeal ? (
+                        <>
+                          <div className="flex items-center gap-2">
+                            <h3 className="text-lg font-bold text-gray-900">
+                              Winner:{' '}
+                              {session.selectedMeal.type === 'meal' ? (
+                                <button
+                                  type="button"
+                                  disabled={loadingRecipeId === session.selectedMeal.id}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    openRecipe(session.selectedMeal!.id);
+                                  }}
+                                  className="text-primary-700 hover:underline disabled:text-gray-400"
+                                >
+                                  {loadingRecipeId === session.selectedMeal.id
+                                    ? 'Loading recipe...'
+                                    : session.selectedMeal.title}
+                                </button>
+                              ) : (
+                                session.selectedMeal.title
+                              )}
+                            </h3>
+                            <span className="px-2 py-0.5 rounded text-xs font-medium bg-orange-50 text-orange-700">
+                              {session.mode === 'takeout' ? 'Order out' : 'Cook at home'}
+                            </span>
+                            <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">
+                              {session.status}
+                            </span>
+                          </div>
+                          <p className="text-sm text-gray-500 mt-1">
+                            {session.mealCount} options · {session.participantCount} participants
+                          </p>
+                          <p className="text-sm text-gray-500 mt-1">
+                            Invite code: <span className="font-mono font-medium">{session.inviteCode}</span>
+                          </p>
+                        </>
+                      ) : (
+                        <>
+                          <div className="flex items-center gap-2">
+                            <span className="font-mono font-bold text-lg">{session.inviteCode}</span>
+                            <span className="px-2 py-0.5 rounded text-xs font-medium bg-orange-50 text-orange-700">
+                              {session.mode === 'takeout' ? 'Order out' : 'Cook at home'}
+                            </span>
+                            <span
+                              className={`px-2 py-0.5 rounded text-xs font-medium ${
+                                session.status === 'open'
+                                  ? 'bg-green-100 text-green-700'
+                                  : 'bg-gray-100 text-gray-700'
+                              }`}
                             >
-                              {loadingRecipeId === session.selectedMeal.id
-                                ? 'Loading recipe...'
-                                : session.selectedMeal.title}
-                            </button>
-                          ) : (
-                            <span className="font-medium">{session.selectedMeal.title}</span>
-                          )}
-                        </p>
+                              {session.status}
+                            </span>
+                          </div>
+                          <p className="text-sm text-gray-500 mt-1">
+                            {session.mealCount} options · {session.participantCount} participants
+                          </p>
+                        </>
                       )}
                     </div>
                     <svg


### PR DESCRIPTION
## Problem and outcome
Closed sessions with a final selection led with an opaque invite code, making the actual choice easy to miss.

## Implemented
- Lead closed recent-session cards with a Winner heading and the selected meal or category.
- Keep the invite code as secondary metadata.
- Preserve recipe viewing for selected home meals and the existing presentation for sessions without a final selection.

## Verification
- npm --prefix client test -- --run src/pages/Dashboard.test.tsx (45 passed)
- npm --prefix client run build

## Exclusions
- No winner is shown for sessions without a final selection.
- No API or schema changes.