### PR TITLE
Add versioned library export and import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Playwright starts its server with a per-run database under `test-results/` and d
 - Public result responses must not expose voter identities. Host voter detail is allowed only after server-side host verification; a query-string flag alone is not authorization.
 - Recipe instructions and ingredients are private host-library data. Reject them for takeout categories, preserve ingredient order and free-text amounts, never add recipe fields to public join, swipe, session, or result payloads, and load host recipe views through an authenticated ownership-checked meal route.
 - Private library notes are host-only data for both meals and categories. Keep them out of public join, swipe, session, and result payloads, and expose them only through authenticated ownership-checked meal routes.
+- Library transfers are authenticated, versioned JSON for active meals and categories. Preserve private recipe data, ingredient order, and notes, assign fresh IDs on import, and never transfer ownership, tokens, counts, history, archived records, or internal IDs.
 - Browser recovery uses both `sessionStorage` for join/session context and `localStorage` for in-progress swipes. Preserve the storage contracts when changing join, share, swipe, edit, or result flows.
 - Declare React hooks before conditional returns and keep effect dependencies accurate. Add regression coverage for async navigation, polling, and storage behavior.
 

--- a/Ideas.md
+++ b/Ideas.md
@@ -10,10 +10,6 @@ Keep this file lean. Add rough thoughts under `## Ungroomed ideas`; keep active 
 
 - **Make selected winners prominent in recent sessions** — On closed sessions with a final selection, lead with the winning meal/category name and retain the invite code as secondary session metadata. Do not invent a winner for sessions without a final selection.
 
-- **Private library notes** — Let hosts add one private free-text note to each home meal or takeout category, opened deliberately from the library rather than shown on cards. Keep notes out of session, swipe, and public-result payloads; defer restaurant/dish-specific notes until a real restaurant model exists.
-
-- **Library export and import** — Transfer active home meals and takeout categories with versioned JSON, validation, preview, and duplicate reporting. Do not transfer IDs, ownership, tokens, counts, or history.
-
 ## Next
 
 - **Weekly planning and shopping lists** — Choose three to five home meals in a separate planning flow and generate a checkable list grouped by meal, preserving ingredients as entered without unit consolidation.

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -149,4 +149,18 @@ describe('API Client - Session Closed Handling', () => {
       body: JSON.stringify({ notes: 'Ask for mild spice.' }),
     }));
   });
+
+  it('previews and confirms versioned library imports', async () => {
+    const data = { version: 1 as const, exportedAt: '2026-08-10T00:00:00Z', options: [] };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ready: 0, imported: 0, duplicates: [], invalid: [] }),
+    });
+
+    await mealsApi.previewImport(data);
+    await mealsApi.importLibrary(data);
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({ data, dryRun: true });
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({ data, dryRun: false });
+  });
 });

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -113,7 +113,43 @@ export interface Meal {
   archived?: boolean;
 }
 
+export interface LibraryExportOption {
+  title: string;
+  type: 'meal' | 'category';
+  description?: string | null;
+  notes?: string | null;
+  instructions?: string | null;
+  ingredients?: RecipeIngredient[];
+}
+
+export interface LibraryExportData {
+  version: 1;
+  exportedAt: string;
+  options: LibraryExportOption[];
+}
+
+export interface LibraryImportPreview {
+  ready: number;
+  imported: number;
+  duplicates: string[];
+  invalid: Array<{ index: number; error: string }>;
+}
+
 export const mealsApi = {
+  exportLibrary: () => request<LibraryExportData>('/meals/export'),
+
+  previewImport: (data: unknown) =>
+    request<LibraryImportPreview>('/meals/import', {
+      method: 'POST',
+      body: JSON.stringify({ data, dryRun: true }),
+    }),
+
+  importLibrary: (data: unknown) =>
+    request<LibraryImportPreview>('/meals/import', {
+      method: 'POST',
+      body: JSON.stringify({ data, dryRun: false }),
+    }),
+
   parseRecipe: (text: string) =>
     request<ParsedRecipe>('/meals/parse-recipe', {
       method: 'POST',

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -16,6 +16,9 @@ vi.mock('../api/client', () => ({
     updatePreferences: vi.fn(),
   },
   mealsApi: {
+    exportLibrary: vi.fn(),
+    previewImport: vi.fn(),
+    importLibrary: vi.fn(),
     parseRecipe: vi.fn(),
     list: vi.fn(),
     get: vi.fn(),
@@ -1321,6 +1324,45 @@ Blend and simmer.`;
     fireEvent.click(screen.getByRole('button', { name: 'Notes' }));
 
     expect(screen.getByRole('dialog', { name: 'Notes for Thai food' })).toBeInTheDocument();
+  });
+
+  it('previews duplicates before importing a library file', async () => {
+    const data = {
+      version: 1 as const,
+      exportedAt: '2026-08-10T12:00:00.000Z',
+      options: [{ title: 'Soup', type: 'meal' as const }],
+    };
+    vi.mocked(mealsApi.previewImport).mockResolvedValue({
+      ready: 1,
+      imported: 0,
+      duplicates: ['Pizza (meal)'],
+      invalid: [],
+    });
+    vi.mocked(mealsApi.importLibrary).mockResolvedValue({
+      ready: 1,
+      imported: 1,
+      duplicates: ['Pizza (meal)'],
+      invalid: [],
+    });
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    await screen.findByText('My Meals');
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    fireEvent.change(screen.getByLabelText('Library JSON file'), {
+      target: { files: [{ text: async () => JSON.stringify(data) }] },
+    });
+
+    expect(await screen.findByText('1 option ready to import')).toBeInTheDocument();
+    expect(screen.getByText('Pizza (meal)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Import 1' }));
+
+    await waitFor(() => expect(mealsApi.importLibrary).toHaveBeenCalledWith(data));
+    expect(await screen.findByText('Imported 1 option.')).toBeInTheDocument();
   });
 
   it('does not show recipe fields for takeout categories', async () => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -7,6 +7,8 @@ import {
   mealsApi,
   sessionsApi,
   Meal,
+  LibraryExportData,
+  LibraryImportPreview,
   RecipeIngredient,
   Session,
   SessionMode,
@@ -74,6 +76,10 @@ export function Dashboard() {
   const [loadingRecipeId, setLoadingRecipeId] = useState<string | null>(null);
   const [notingMeal, setNotingMeal] = useState<Meal | null>(null);
   const [notesDraft, setNotesDraft] = useState('');
+  const [showLibraryImport, setShowLibraryImport] = useState(false);
+  const [libraryImportData, setLibraryImportData] = useState<LibraryExportData | null>(null);
+  const [libraryImportPreview, setLibraryImportPreview] = useState<LibraryImportPreview | null>(null);
+  const [libraryTransferLoading, setLibraryTransferLoading] = useState(false);
 
   // Animation states
   const [deletingMealIds, setDeletingMealIds] = useState<string[]>([]);
@@ -299,6 +305,65 @@ export function Dashboard() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save notes');
     }
+  };
+
+  const handleExportLibrary = async () => {
+    setLibraryTransferLoading(true);
+    try {
+      const data = await mealsApi.exportLibrary();
+      const url = URL.createObjectURL(new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json',
+      }));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `mealmatch-library-${new Date().toISOString().slice(0, 10)}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to export library');
+    } finally {
+      setLibraryTransferLoading(false);
+    }
+  };
+
+  const handleImportFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setLibraryTransferLoading(true);
+    try {
+      const data = JSON.parse(await file.text()) as LibraryExportData;
+      const preview = await mealsApi.previewImport(data);
+      setLibraryImportData(data);
+      setLibraryImportPreview(preview);
+    } catch (err) {
+      setLibraryImportData(null);
+      setLibraryImportPreview(null);
+      setError(err instanceof Error ? err.message : 'Failed to read import file');
+    } finally {
+      setLibraryTransferLoading(false);
+      event.target.value = '';
+    }
+  };
+
+  const handleConfirmImport = async () => {
+    if (!libraryImportData) return;
+    setLibraryTransferLoading(true);
+    try {
+      const result = await mealsApi.importLibrary(libraryImportData);
+      setLibraryImportPreview(result);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to import library');
+    } finally {
+      setLibraryTransferLoading(false);
+    }
+  };
+
+  const closeLibraryImport = () => {
+    setShowLibraryImport(false);
+    setLibraryImportData(null);
+    setLibraryImportPreview(null);
   };
 
   const handleDeleteMeal = async (id: string) => {
@@ -540,9 +605,26 @@ export function Dashboard() {
               )}
             </div>
             {!editMode && (
-              <button onClick={openAddMeal} className="btn btn-primary">
-                {activeMode === 'home' ? 'Add Meal' : 'Add Category'}
-              </button>
+              <div className="flex flex-wrap justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleExportLibrary}
+                  disabled={libraryTransferLoading}
+                  className="btn btn-secondary"
+                >
+                  Export
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowLibraryImport(true)}
+                  className="btn btn-secondary"
+                >
+                  Import
+                </button>
+                <button onClick={openAddMeal} className="btn btn-primary">
+                  {activeMode === 'home' ? 'Add Meal' : 'Add Category'}
+                </button>
+              </div>
             )}
           </div>
 
@@ -838,6 +920,91 @@ export function Dashboard() {
               >
                 Add selected ({selectedStarterCategories.length})
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Library Import Modal */}
+      {showLibraryImport && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div
+            className="card w-full max-w-lg max-h-[90vh] overflow-y-auto"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="library-import-title"
+          >
+            <h3 id="library-import-title" className="text-xl font-bold mb-2">Import library</h3>
+            <p className="text-sm text-gray-600 mb-4">
+              Choose a MealMatch JSON export to preview new options and duplicates before saving.
+            </p>
+            <label className="btn btn-secondary inline-block cursor-pointer">
+              Choose JSON file
+              <input
+                type="file"
+                accept="application/json,.json"
+                onChange={handleImportFile}
+                className="sr-only"
+                aria-label="Library JSON file"
+              />
+            </label>
+
+            {libraryTransferLoading && <p className="mt-4 text-sm text-gray-500">Checking file...</p>}
+
+            {libraryImportPreview && (
+              <div className="mt-5 space-y-3" aria-live="polite">
+                {libraryImportPreview.imported > 0 ? (
+                  <p className="rounded-lg bg-green-50 px-3 py-2 text-green-700">
+                    Imported {libraryImportPreview.imported} option{
+                      libraryImportPreview.imported === 1 ? '' : 's'
+                    }.
+                  </p>
+                ) : (
+                  <p className="font-medium">
+                    {libraryImportPreview.ready} option{
+                      libraryImportPreview.ready === 1 ? '' : 's'
+                    } ready to import
+                  </p>
+                )}
+                {libraryImportPreview.duplicates.length > 0 && (
+                  <div>
+                    <h4 className="font-medium">Duplicates skipped</h4>
+                    <ul className="list-disc pl-5 text-sm text-gray-600">
+                      {libraryImportPreview.duplicates.map((duplicate) => (
+                        <li key={duplicate}>{duplicate}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {libraryImportPreview.invalid.length > 0 && (
+                  <div>
+                    <h4 className="font-medium">Invalid entries skipped</h4>
+                    <ul className="list-disc pl-5 text-sm text-red-600">
+                      {libraryImportPreview.invalid.map((entry) => (
+                        <li key={`${entry.index}-${entry.error}`}>
+                          Option {entry.index + 1}: {entry.error}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="flex gap-3 mt-6">
+              <button type="button" onClick={closeLibraryImport} className="btn btn-secondary flex-1">
+                {libraryImportPreview?.imported ? 'Done' : 'Cancel'}
+              </button>
+              {libraryImportPreview && libraryImportPreview.imported === 0 && (
+                <button
+                  type="button"
+                  onClick={handleConfirmImport}
+                  disabled={libraryTransferLoading || libraryImportPreview.ready === 0}
+                  className="btn btn-primary flex-1"
+                >
+                  Import {libraryImportPreview.ready}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/e2e/meal-management.spec.ts
+++ b/e2e/meal-management.spec.ts
@@ -61,6 +61,89 @@ test.describe('Meal Management (#17, #12)', () => {
     await expect(page.locator('text=Original Title')).not.toBeVisible();
   });
 
+  test('host can export, preview, and import active library data', async ({ page }) => {
+    const uniqueEmail = `test-transfer-${Date.now()}@example.com`;
+    await registerAndGoToDashboard(page, uniqueEmail);
+    await addMeal(page, 'Backup Soup', 'Warm and filling');
+
+    await page.getByRole('button', { name: 'Notes' }).click();
+    const notesDialog = page.getByRole('dialog', { name: 'Notes for Backup Soup' });
+    await notesDialog.getByLabel('Private notes').fill('Serve with bread.');
+    await notesDialog.getByRole('button', { name: 'Save notes' }).click();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export' }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/^mealmatch-library-\d{4}-\d{2}-\d{2}\.json$/);
+
+    const exported = await page.evaluate(async () => {
+      const response = await fetch('/api/meals/export');
+      return { status: response.status, body: await response.json() };
+    });
+    expect(exported.status).toBe(200);
+    expect(exported.body).toMatchObject({
+      version: 1,
+      options: [{
+        title: 'Backup Soup',
+        type: 'meal',
+        description: 'Warm and filling',
+        notes: 'Serve with bread.',
+        instructions: null,
+        ingredients: [],
+      }],
+    });
+    expect(exported.body.options[0]).not.toHaveProperty('id');
+    expect(exported.body.options[0]).not.toHaveProperty('pickCount');
+    expect(exported.body.options[0]).not.toHaveProperty('hostId');
+
+    await page.getByTitle('Archive meal').click();
+    await page.getByRole('button', { name: 'Confirm' }).click();
+    await expect(page.getByText('Backup Soup', { exact: true })).not.toBeVisible();
+
+    const preview = await page.evaluate(async (data) => {
+      const response = await fetch('/api/meals/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data, dryRun: true }),
+      });
+      return { status: response.status, body: await response.json() };
+    }, exported.body);
+    expect(preview).toMatchObject({
+      status: 200,
+      body: { ready: 1, imported: 0, duplicates: [], invalid: [] },
+    });
+
+    const imported = await page.evaluate(async (data) => {
+      const response = await fetch('/api/meals/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data, dryRun: false }),
+      });
+      return { status: response.status, body: await response.json() };
+    }, exported.body);
+    expect(imported).toMatchObject({ status: 200, body: { ready: 1, imported: 1 } });
+
+    await page.reload();
+    await expect(page.getByText('Backup Soup', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Notes' }).click();
+    await expect(page.getByLabel('Private notes')).toHaveValue('Serve with bread.');
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    const duplicatePreview = await page.evaluate(async (data) => {
+      const response = await fetch('/api/meals/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data, dryRun: true }),
+      });
+      return response.json();
+    }, exported.body);
+    expect(duplicatePreview).toMatchObject({
+      ready: 0,
+      imported: 0,
+      duplicates: ['Backup Soup (meal)'],
+    });
+  });
+
   test('host can save private recipe details and notes without exposing them to session participants', async ({ page, request }) => {
     const uniqueEmail = `test-recipe-${Date.now()}@example.com`;
     await registerAndGoToDashboard(page, uniqueEmail);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -39,6 +39,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Body parsers
+app.use('/api/meals/import', express.json({ limit: '5mb' }));
 app.use(express.json());
 
 // Session middleware

--- a/server/src/routes/meals.ts
+++ b/server/src/routes/meals.ts
@@ -1,7 +1,14 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { runQuery, getOne, getAll, getDatabase, saveDatabase } from '../db/schema';
-import { Meal, MealIngredient, MealType, CreateMealRequest } from '../types';
+import {
+  Meal,
+  MealIngredient,
+  MealType,
+  CreateMealRequest,
+  LibraryExportData,
+  LibraryExportOption,
+} from '../types';
 import { requireAuth } from '../middleware/auth';
 import {
   normalizeIngredients,
@@ -9,6 +16,10 @@ import {
   parseRecipeText,
   RecipeValidationError,
 } from '../services/recipe';
+import {
+  LibraryTransferValidationError,
+  parseLibraryExport,
+} from '../services/library-transfer';
 
 const router = Router();
 
@@ -151,6 +162,115 @@ router.get('/all', (req, res) => {
     res.json(meals.map(meal => toLibraryMealResponse(meal, true)));
   } catch (error) {
     console.error('Get all meals error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /api/meals/export - Export active host library data without internal metadata
+router.get('/export', (req, res) => {
+  try {
+    const meals = getAll<Meal>(
+      `SELECT id, title, description, instructions, notes, type
+       FROM meals
+       WHERE host_id = ? AND archived = 0 AND type IN ('meal', 'category')
+       ORDER BY type, title`,
+      [req.session.hostId]
+    );
+    const options: LibraryExportOption[] = meals.map((meal) => meal.type === 'meal'
+      ? {
+          title: meal.title,
+          type: 'meal',
+          description: meal.description,
+          notes: meal.notes ?? null,
+          instructions: meal.instructions ?? null,
+          ingredients: getMealIngredients(meal.id),
+        }
+      : {
+          title: meal.title,
+          type: 'category',
+          notes: meal.notes ?? null,
+        });
+    const data: LibraryExportData = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      options,
+    };
+    res.json(data);
+  } catch (error) {
+    console.error('Export library error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /api/meals/import - Preview or import active library data
+router.post('/import', (req, res) => {
+  try {
+    const { data, dryRun } = req.body ?? {};
+    if (typeof dryRun !== 'boolean') {
+      res.status(400).json({ error: 'dryRun must be a boolean' });
+      return;
+    }
+
+    const { valid, invalid } = parseLibraryExport(data);
+    const existing = getAll<Pick<Meal, 'title' | 'type'>>(
+      `SELECT title, type FROM meals
+       WHERE host_id = ? AND archived = 0 AND type IN ('meal', 'category')`,
+      [req.session.hostId]
+    );
+    const seen = new Set(existing.map((meal) => `${meal.type}:${meal.title.toLowerCase()}`));
+    const duplicates: string[] = [];
+    const ready: LibraryExportOption[] = [];
+
+    valid.forEach((option) => {
+      const key = `${option.type}:${option.title.toLowerCase()}`;
+      if (seen.has(key)) {
+        duplicates.push(`${option.title} (${option.type})`);
+        return;
+      }
+      seen.add(key);
+      ready.push(option);
+    });
+
+    if (!dryRun && ready.length > 0) {
+      runTransaction((database) => {
+        ready.forEach((option) => {
+          const id = uuidv4();
+          database.run(
+            `INSERT INTO meals (id, host_id, title, description, instructions, notes, type)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            [
+              id,
+              req.session.hostId,
+              option.title,
+              option.type === 'meal' ? option.description ?? null : null,
+              option.type === 'meal' ? option.instructions ?? null : null,
+              option.notes ?? null,
+              option.type,
+            ]
+          );
+          if (option.type === 'meal') addIngredients(database, id, option.ingredients ?? []);
+        });
+        if (ready.some((option) => option.type === 'category')) {
+          database.run(
+            'UPDATE hosts SET takeout_onboarding_dismissed = 1 WHERE id = ?',
+            [req.session.hostId]
+          );
+        }
+      });
+    }
+
+    res.json({
+      ready: ready.length,
+      imported: dryRun ? 0 : ready.length,
+      duplicates,
+      invalid,
+    });
+  } catch (error) {
+    if (error instanceof LibraryTransferValidationError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    console.error('Import library error:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/server/src/services/library-transfer.test.ts
+++ b/server/src/services/library-transfer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { LibraryTransferValidationError, parseLibraryExport } from './library-transfer';
+
+describe('library transfer validation', () => {
+  it('normalizes meals and categories while preserving ingredient order', () => {
+    expect(parseLibraryExport({
+      version: 1,
+      options: [
+        {
+          title: ' Soup ',
+          type: 'meal',
+          description: ' Warm ',
+          notes: ' Winter ',
+          instructions: ' Simmer ',
+          ingredients: [
+            { amount: ' 2 cups ', ingredient: ' stock ' },
+            { amount: '', ingredient: ' salt ' },
+          ],
+        },
+        { title: ' Thai ', type: 'category', notes: ' Try curry ' },
+      ],
+    }).valid).toEqual([
+      {
+        title: 'Soup',
+        type: 'meal',
+        description: 'Warm',
+        notes: 'Winter',
+        instructions: 'Simmer',
+        ingredients: [
+          { amount: '2 cups', ingredient: 'stock' },
+          { amount: '', ingredient: 'salt' },
+        ],
+      },
+      { title: 'Thai', type: 'category', notes: 'Try curry' },
+    ]);
+  });
+
+  it('reports invalid entries without rejecting valid entries', () => {
+    const result = parseLibraryExport({
+      version: 1,
+      options: [
+        { title: 'Pizza', type: 'category' },
+        { title: '', type: 'meal' },
+        { title: 'Italian', type: 'category', instructions: 'Nope' },
+      ],
+    });
+
+    expect(result.valid).toHaveLength(1);
+    expect(result.invalid).toEqual([
+      { index: 1, error: 'Title is required' },
+      { index: 2, error: 'Categories cannot contain recipe fields' },
+    ]);
+  });
+
+  it('rejects unsupported export versions', () => {
+    expect(() => parseLibraryExport({ version: 2, options: [] }))
+      .toThrow(LibraryTransferValidationError);
+  });
+});

--- a/server/src/services/library-transfer.ts
+++ b/server/src/services/library-transfer.ts
@@ -1,0 +1,85 @@
+import { LibraryExportData, LibraryExportOption, MealIngredient } from '../types';
+import { normalizeIngredients, normalizeInstructions, RecipeValidationError } from './recipe';
+
+export class LibraryTransferValidationError extends Error {}
+
+function normalizeOptionalText(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') {
+    throw new LibraryTransferValidationError(`${field} must be text or null`);
+  }
+  return value.trim() || null;
+}
+
+export function parseLibraryExport(value: unknown): {
+  valid: LibraryExportOption[];
+  invalid: Array<{ index: number; error: string }>;
+} {
+  if (!value || typeof value !== 'object') {
+    throw new LibraryTransferValidationError('Import data must be an object');
+  }
+
+  const data = value as Partial<LibraryExportData>;
+  if (data.version !== 1) {
+    throw new LibraryTransferValidationError('Unsupported library export version');
+  }
+  if (!Array.isArray(data.options)) {
+    throw new LibraryTransferValidationError('Import data must contain an options array');
+  }
+  if (data.options.length > 1_000) {
+    throw new LibraryTransferValidationError('Import data cannot contain more than 1000 options');
+  }
+
+  const valid: LibraryExportOption[] = [];
+  const invalid: Array<{ index: number; error: string }> = [];
+
+  data.options.forEach((raw, index) => {
+    try {
+      if (!raw || typeof raw !== 'object') {
+        throw new LibraryTransferValidationError('Option must be an object');
+      }
+      const option = raw as unknown as Record<string, unknown>;
+      if (typeof option.title !== 'string' || !option.title.trim()) {
+        throw new LibraryTransferValidationError('Title is required');
+      }
+      if (option.type !== 'meal' && option.type !== 'category') {
+        throw new LibraryTransferValidationError('Type must be meal or category');
+      }
+
+      const title = option.title.trim();
+      const notes = normalizeOptionalText(option.notes, 'Notes');
+      if (option.type === 'category') {
+        if (option.description != null || option.instructions != null || option.ingredients != null) {
+          throw new LibraryTransferValidationError('Categories cannot contain recipe fields');
+        }
+        valid.push({ title, type: 'category', notes });
+        return;
+      }
+
+      let ingredients: MealIngredient[] = [];
+      try {
+        ingredients = option.ingredients === undefined ? [] : normalizeIngredients(option.ingredients);
+      } catch (error) {
+        if (error instanceof RecipeValidationError) {
+          throw new LibraryTransferValidationError(error.message);
+        }
+        throw error;
+      }
+      valid.push({
+        title,
+        type: 'meal',
+        description: normalizeOptionalText(option.description, 'Description'),
+        notes,
+        instructions: normalizeInstructions(option.instructions ?? null),
+        ingredients,
+      });
+    } catch (error) {
+      invalid.push({
+        index,
+        error: error instanceof Error ? error.message : 'Invalid option',
+      });
+    }
+  });
+
+  return { valid, invalid };
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -109,6 +109,21 @@ export interface CreateMealRequest {
   ingredients?: MealIngredient[];
 }
 
+export interface LibraryExportOption {
+  title: string;
+  type: 'meal' | 'category';
+  description?: string | null;
+  notes?: string | null;
+  instructions?: string | null;
+  ingredients?: MealIngredient[];
+}
+
+export interface LibraryExportData {
+  version: 1;
+  exportedAt: string;
+  options: LibraryExportOption[];
+}
+
 export interface CreateSessionRequest {
   mealIds: string[];
   mode?: SessionMode;


### PR DESCRIPTION
## Problem and outcome
Hosts need a portable backup of their MealMatch libraries. This adds authenticated, versioned JSON export and a preview-first import flow for active home meals and takeout categories.

This PR is stacked on #39 because transfers include the private notes introduced there. Merge #39 first, then retarget or merge this PR.

## First slice
- Download active library options as version 1 JSON from the dashboard.
- Preview valid entries, case-insensitive duplicates, and invalid rows before writing.
- Confirm imports in one transaction with fresh internal IDs.
- Preserve meal descriptions, private notes, recipe instructions, and ingredient order.
- Support recipe-rich uploads up to 5 MB only on the import endpoint.

## Decisions and exclusions
- Archived options are not exported.
- Ownership, internal IDs, tokens, selection counts, and history are never transferred.
- Duplicates are matched by option type and title and skipped.
- Invalid rows are reported and skipped while valid rows remain importable.
- No unit consolidation or cross-account sync is included.

## Implementation notes
- Export and import routes remain behind the existing host authentication middleware.
- Import validation is version-aware and caps files at 1000 options.
- Confirmed imports use a database transaction and dismiss takeout onboarding when categories are added.

## Verification
- npm test: 137 passed (35 server, 102 client)
- npm run lint
- npm --prefix client run build
- npm --prefix server run build
- npm run test:e2e -- e2e/meal-management.spec.ts: 7 passed

## Deferred follow-ups
None required for this slice.